### PR TITLE
Merge `Reflectance` implementation and supporting code.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ lazy_static = "1.4.*"
 nalgebra = { version = "0.31.*", features = ["serde-serialize"] }
 ndarray = { version = "0.15.*", features = ["rayon", "serde-1"] }
 ndarray-stats = "0.5.*"
-ndarray-parallel = "0.9.*"
 num_cpus = "1.13.*"
 palette = "0.6.*"
 physical_constants = "0.4.*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ dimensioned = "0.7.*"
 hex = "0.4.*"
 indicatif = "0.16.*"
 lazy_static = "1.4.*"
-nalgebra = { version = "0.30.*", features = ["serde-serialize"] }
+nalgebra = { version = "0.31.*", features = ["serde-serialize"] }
 ndarray = { version = "0.15.*", features = ["rayon", "serde-1"] }
 ndarray-stats = "0.5.*"
 ndarray-parallel = "0.9.*"
@@ -44,7 +44,7 @@ serde_json = "^1.0.*"
 slice-of-array = "0.3.*"
 splines = { version = "4.0.*", features = ["serde"] }
 statrs = "0.15.*"
-terminal_size = "0.1.*"
+terminal_size = "0.2.*"
 cubic-splines = "0.2.0"
 lidrs = "0.2.*"
 

--- a/src/data/histogram.rs
+++ b/src/data/histogram.rs
@@ -5,6 +5,7 @@ use crate::{
     err::Error,
     fmt_report,
     fs::Save,
+    data::HistogramIterator,
     tools::{Binner, Range},
 };
 use ndarray::Array1;
@@ -85,6 +86,11 @@ impl Histogram {
         if let Some(index) = self.binner.try_bin(x) {
             self.counts[index] += weight;
         }
+    }
+
+    #[inline]
+    pub fn iter(&self) -> HistogramIterator {
+        HistogramIterator::new(self)
     }
 }
 

--- a/src/data/histogram.rs
+++ b/src/data/histogram.rs
@@ -2,10 +2,10 @@
 
 use crate::{
     access,
+    data::HistogramIterator,
     err::Error,
     fmt_report,
     fs::Save,
-    data::HistogramIterator,
     tools::{Binner, Range},
 };
 use ndarray::Array1;

--- a/src/data/histogram_iter.rs
+++ b/src/data/histogram_iter.rs
@@ -23,10 +23,11 @@ impl<'a> Iterator for HistogramIterator<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         let nbin = self.hist.binner().bins();
 
-        if self.curr_bin < nbin{
-            let bin = self.hist.binner().range().min() + (self.curr_bin as Real * self.hist.binner().bin_width());
+        if self.curr_bin < nbin {
+            let bin = self.hist.binner().range().min()
+                + (self.curr_bin as Real * self.hist.binner().bin_width());
             let count = self.hist.counts()[self.curr_bin];
-            
+
             self.curr_bin += 1;
 
             Some((bin, count))

--- a/src/data/histogram_iter.rs
+++ b/src/data/histogram_iter.rs
@@ -1,0 +1,38 @@
+use super::Histogram;
+use crate::core::Real;
+
+pub struct HistogramIterator<'a> {
+    /// The `Histogram` instance we are iterating.
+    hist: &'a Histogram,
+    /// The current bin within the histogram.
+    curr_bin: usize,
+}
+
+impl<'a> HistogramIterator<'a> {
+    // Construct a new HistogramIterator.
+    #[inline]
+    #[must_use]
+    pub fn new(hist: &'a Histogram) -> Self {
+        Self { hist, curr_bin: 0 }
+    }
+}
+
+impl<'a> Iterator for HistogramIterator<'a> {
+    type Item = (Real, Real);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let nbin = self.hist.binner().bins();
+
+        if self.curr_bin < nbin{
+            let bin = self.hist.binner().range().min() + (self.curr_bin as Real * self.hist.binner().bin_width());
+            let count = self.hist.counts()[self.curr_bin];
+            
+            self.curr_bin += 1;
+
+            Some((bin, count))
+        } else {
+            self.curr_bin += 1;
+            None
+        }
+    }
+}

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod average;
 pub mod histogram;
+pub mod histogram_iter;
 pub mod table;
 
-pub use self::{average::*, histogram::*, table::*};
+pub use self::{average::*, histogram::*, histogram_iter::*, table::*};

--- a/src/fs/extensions/lid.rs
+++ b/src/fs/extensions/lid.rs
@@ -68,7 +68,7 @@ TILT=INCLUDE
                 let mut rng = rand::thread_rng();
                 //let mut test_file = std::fs::File::create("samples.dat").unwrap();
                 for _ in 0..10_000 {
-                    let (azim, pol) = cdf.sample(&mut rng);
+                    let (_azim, _pol) = cdf.sample(&mut rng);
                     //let _ = write!(test_file, "{}\t{}\n", azim, pol);
                 }
             }

--- a/src/fs/extensions/wavefront.rs
+++ b/src/fs/extensions/wavefront.rs
@@ -4,7 +4,7 @@ use crate::{
     err::Error,
     fs::File,
     geom::{Mesh, SmoothTriangle},
-    math::{Dir3, Point3, Vec3},
+    math::{Dir3, Point3},
 };
 use std::{
     io::{BufRead, BufReader},

--- a/src/geom/rt/orient.rs
+++ b/src/geom/rt/orient.rs
@@ -35,11 +35,11 @@ impl Orient {
     pub fn new(ray: Ray) -> Self {
         let (pos, forward) = ray.destruct();
         let right = if forward.z().abs() <= 0.9 {
-            Dir3::from(forward.cross_dir(&Vec3::z_axis())) // Universal up is z-axis.
+            Dir3::from(forward.cross(&Vec3::z_axis())) // Universal up is z-axis.
         } else {
-            Dir3::from(forward.cross_dir(&Vec3::x_axis())) // If facing along z-axis, compute relative up using x-axis.
+            Dir3::from(forward.cross(&Vec3::x_axis())) // If facing along z-axis, compute relative up using x-axis.
         };
-        let up = Dir3::from(right.cross_dir(&forward));
+        let up = Dir3::from(right.cross(&forward));
 
         Self {
             pos,
@@ -54,8 +54,8 @@ impl Orient {
     #[must_use]
     pub fn new_up(ray: Ray, up: &Dir3) -> Self {
         let (pos, forward) = ray.destruct();
-        let right = Dir3::from(forward.cross_dir(up));
-        let up = Dir3::from(right.cross_dir(&forward));
+        let right = Dir3::from(forward.cross(up));
+        let up = Dir3::from(right.cross(&forward));
 
         Self {
             pos,

--- a/src/geom/rt/ray.rs
+++ b/src/geom/rt/ray.rs
@@ -53,7 +53,7 @@ impl Ray {
             Vec3::y_axis()
         };
 
-        let pitch_axis = self.dir.cross(&arbitrary_axis.into());
+        let pitch_axis = self.dir.cross_vec(&arbitrary_axis.into());
         let pitch_rot = Rot3::from_axis_angle(&Vec3::from(pitch_axis), pitch);
         let roll_rot = Rot3::from_axis_angle(&Vec3::from(self.dir), roll);
 

--- a/src/geom/rt/ray.rs
+++ b/src/geom/rt/ray.rs
@@ -9,7 +9,7 @@ use crate::{
 ///
 /// This is the type at the core of our ray tracing / hit scan implementation.
 /// This is also the type at the core of our photon implementation.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Ray {
     /// Ray origin.
     pos: Point3,

--- a/src/geom/rt/ray.rs
+++ b/src/geom/rt/ray.rs
@@ -25,7 +25,7 @@ impl Ray {
     #[inline]
     #[must_use]
     pub fn new(pos: Point3, mut dir: Dir3) -> Self {
-        dir.renormalize();
+        let _ = dir.renormalize();
         Self { pos, dir }
     }
 
@@ -58,7 +58,7 @@ impl Ray {
         let roll_rot = Rot3::from_axis_angle(&Vec3::from(self.dir), roll);
 
         self.dir = roll_rot * pitch_rot * self.dir;
-        self.dir.renormalize();
+        let _ = self.dir.renormalize();
     }
 }
 

--- a/src/geom/shape/triangle.rs
+++ b/src/geom/shape/triangle.rs
@@ -100,7 +100,7 @@ impl Triangle {
         let e1 = verts[BETA] - verts[ALPHA];
         let e2 = verts[GAMMA] - verts[ALPHA];
 
-        let d_cross_e2 = ray.dir().cross(&e2.into());
+        let d_cross_e2 = ray.dir().cross_vec(&e2.into());
         let e1_dot_d_cross_e2 = e1.dot(&d_cross_e2);
 
         if e1_dot_d_cross_e2.abs() <= 0.0 {
@@ -181,17 +181,17 @@ impl Collide for Triangle {
             return false;
         }
 
-        let axis_u0_f0 = u0.cross(&f0);
-        let axis_u0_f1 = u0.cross(&f1);
-        let axis_u0_f2 = u0.cross(&f2);
+        let axis_u0_f0 = u0.cross_vec(&f0);
+        let axis_u0_f1 = u0.cross_vec(&f1);
+        let axis_u0_f2 = u0.cross_vec(&f2);
 
-        let axis_u1_f0 = u1.cross(&f0);
-        let axis_u1_f1 = u1.cross(&f1);
-        let axis_u1_f2 = u1.cross(&f2);
+        let axis_u1_f0 = u1.cross_vec(&f0);
+        let axis_u1_f1 = u1.cross_vec(&f1);
+        let axis_u1_f2 = u1.cross_vec(&f2);
 
-        let axis_u2_f0 = u2.cross(&f0);
-        let axis_u2_f1 = u2.cross(&f1);
-        let axis_u2_f2 = u2.cross(&f2);
+        let axis_u2_f0 = u2.cross_vec(&f0);
+        let axis_u2_f1 = u2.cross_vec(&f1);
+        let axis_u2_f2 = u2.cross_vec(&f2);
 
         if !axis_test(&axis_u0_f0) {
             return false;

--- a/src/geom/shape/triangle.rs
+++ b/src/geom/shape/triangle.rs
@@ -116,7 +116,7 @@ impl Triangle {
         }
 
         let q = rel_pos.cross(&e1);
-        let v = inv_e1_dot_d_cross_e2 * ray.dir().dot(&q.dir());
+        let v = inv_e1_dot_d_cross_e2 * ray.dir().dot_vec(&q);
 
         if (v < 0.0) || ((u + v) > 1.0) {
             return None;
@@ -159,9 +159,9 @@ impl Collide for Triangle {
             let p2 = v2.dot(axis);
 
             let r = e.z().mul_add(
-                u2.dot(&axis.dir()).abs(),
+                u2.dot_vec(axis).abs(),
                 e.x()
-                    .mul_add(u0.dot(&axis.dir()).abs(), e.y() * u1.dot(&axis.dir()).abs()),
+                    .mul_add(u0.dot_vec(axis).abs(), e.y() * u1.dot_vec(axis).abs()),
             );
 
             if (-(p0.max(p1).max(p2))).max(p0.min(p1).min(p2)) > r {

--- a/src/math/linalg/dir/dir2.rs
+++ b/src/math/linalg/dir/dir2.rs
@@ -60,6 +60,8 @@ impl Neg for Dir2 {
     type Output = Self;
 
     /// Negation implementation for Dir2. 
+    #[inline]
+    #[must_use]
     fn neg(self) -> Self::Output {
         return Self::new(-self.x(), -self.y());
     }
@@ -68,12 +70,16 @@ impl Neg for Dir2 {
 impl Sub<Dir2> for Dir2 {
     type Output = Self;
 
+    #[inline]
+    #[must_use]
     fn sub(self, rhs: Dir2) -> Self::Output {
         Self::new(self.x() - rhs.x(), self.y() - rhs.y())
     }
 }
 
 impl PartialEq for Dir2 {
+    #[inline]
+    #[must_use]
     fn eq(&self, other: &Self) -> bool {
         self.data == other.data
     }

--- a/src/math/linalg/dir/dir2.rs
+++ b/src/math/linalg/dir/dir2.rs
@@ -3,9 +3,7 @@
 use crate::{clone, core::Real};
 use nalgebra::{Unit, Vector2};
 use serde_derive::{Deserialize, Serialize};
-use std::{
-    ops::{Neg, Sub}
-};
+use std::ops::{Neg, Sub};
 
 /// Normalised two dimensional real-number vector.
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
@@ -59,7 +57,7 @@ impl From<Unit<Vector2<Real>>> for Dir2 {
 impl Neg for Dir2 {
     type Output = Self;
 
-    /// Negation implementation for Dir2. 
+    /// Negation implementation for Dir2.
     #[inline]
     #[must_use]
     fn neg(self) -> Self::Output {
@@ -107,7 +105,7 @@ mod tests {
         assert_approx_eq!(-test_pos.x(), test_neg.x());
         assert_approx_eq!(-test_pos.y(), test_neg.y());
 
-        // Now test the inverse. 
+        // Now test the inverse.
         assert_approx_eq!(-test_neg.x(), test_pos.x());
         assert_approx_eq!(-test_neg.y(), test_pos.y());
     }

--- a/src/math/linalg/dir/dir2.rs
+++ b/src/math/linalg/dir/dir2.rs
@@ -2,9 +2,11 @@
 
 use crate::{clone, core::Real};
 use nalgebra::{Unit, Vector2};
+use serde_derive::{Deserialize, Serialize};
 
 /// Normalised two dimensional real-number vector.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[serde(transparent)]
 pub struct Dir2 {
     /// Internal data.
     data: Unit<Vector2<Real>>,

--- a/src/math/linalg/dir/dir2.rs
+++ b/src/math/linalg/dir/dir2.rs
@@ -3,6 +3,9 @@
 use crate::{clone, core::Real};
 use nalgebra::{Unit, Vector2};
 use serde_derive::{Deserialize, Serialize};
+use std::{
+    ops::{Neg, Sub}
+};
 
 /// Normalised two dimensional real-number vector.
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
@@ -53,6 +56,29 @@ impl From<Unit<Vector2<Real>>> for Dir2 {
     }
 }
 
+impl Neg for Dir2 {
+    type Output = Self;
+
+    /// Negation implementation for Dir2. 
+    fn neg(self) -> Self::Output {
+        return Self::new(-self.x(), -self.y());
+    }
+}
+
+impl Sub<Dir2> for Dir2 {
+    type Output = Self;
+
+    fn sub(self, rhs: Dir2) -> Self::Output {
+        Self::new(self.x() - rhs.x(), self.y() - rhs.y())
+    }
+}
+
+impl PartialEq for Dir2 {
+    fn eq(&self, other: &Self) -> bool {
+        self.data == other.data
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -64,5 +90,19 @@ mod tests {
 
         assert_approx_eq!(v.x(), 0.6);
         assert_approx_eq!(v.y(), -0.8);
+    }
+
+    #[test]
+    fn test_dir2_neg() {
+        let test_pos = Dir2::new(1.0, 1.0);
+        let test_neg = Dir2::new(-1.0, -1.0);
+
+        // First test that positive components get made negative.
+        assert_approx_eq!(-test_pos.x(), test_neg.x());
+        assert_approx_eq!(-test_pos.y(), test_neg.y());
+
+        // Now test the inverse. 
+        assert_approx_eq!(-test_neg.x(), test_pos.x());
+        assert_approx_eq!(-test_neg.y(), test_pos.y());
     }
 }

--- a/src/math/linalg/dir/dir3.rs
+++ b/src/math/linalg/dir/dir3.rs
@@ -184,6 +184,7 @@ impl Mul<&Dir3> for f64 {
 impl Neg for Dir3 {
     type Output = Self;
 
+    /// Negation implementation for Dir3. 
     fn neg(self) -> Self::Output {
         return Self::new(-self.x(), -self.y(), -self.z());
     }
@@ -210,5 +211,36 @@ impl PartialOrd for Dir3 {
 impl PartialEq for Dir3 {
     fn eq(&self, other: &Self) -> bool {
         self.data == other.data
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert_approx_eq::assert_approx_eq;
+
+    #[test]
+    fn test_init() {
+        let v = Dir3::new(3.0, -4.0, 3.0);
+
+        assert_approx_eq!(v.x(), 0.5144957554275265);
+        assert_approx_eq!(v.y(), -0.6859943405700353);
+        assert_approx_eq!(v.z(), 0.5144957554275265);
+    }
+
+    #[test]
+    fn test_dir3_neg() {
+        let test_pos = Dir3::new(1.0, 1.0, 1.0);
+        let test_neg = Dir3::new(-1.0, -1.0, -1.0);
+
+        // First test that positive components get made negative.
+        assert_approx_eq!(-test_pos.x(), test_neg.x());
+        assert_approx_eq!(-test_pos.y(), test_neg.y());
+        assert_approx_eq!(-test_pos.z(), test_neg.z());
+
+        // Now test the inverse. 
+        assert_approx_eq!(-test_neg.x(), test_pos.x());
+        assert_approx_eq!(-test_neg.y(), test_pos.y());
+        assert_approx_eq!(-test_neg.z(), test_pos.z());
     }
 }

--- a/src/math/linalg/dir/dir3.rs
+++ b/src/math/linalg/dir/dir3.rs
@@ -148,6 +148,8 @@ impl From<Unit<Vector3<Real>>> for Dir3 {
 impl Mul<f64> for Dir3 {
     type Output = Vec3;
 
+    #[inline]
+    #[must_use]
     fn mul(self, rhs: f64) -> Vec3 {
         return Vec3::new(self.x() * rhs, self.y() * rhs, self.z() * rhs);
     }
@@ -185,6 +187,8 @@ impl Neg for Dir3 {
     type Output = Self;
 
     /// Negation implementation for Dir3. 
+    #[inline]
+    #[must_use]
     fn neg(self) -> Self::Output {
         return Self::new(-self.x(), -self.y(), -self.z());
     }
@@ -193,6 +197,8 @@ impl Neg for Dir3 {
 impl Add<Dir3> for Dir3 {
     type Output = Dir3;
 
+    #[inline]
+    #[must_use]
     fn add(self, rhs: Dir3) -> Self::Output {
         Dir3::new(
             self.data.x + rhs.data.x,
@@ -203,6 +209,8 @@ impl Add<Dir3> for Dir3 {
 }
 
 impl PartialOrd for Dir3 {
+    #[inline]
+    #[must_use]
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         self.data.partial_cmp(&other.data)
     }

--- a/src/math/linalg/dir/dir3.rs
+++ b/src/math/linalg/dir/dir3.rs
@@ -7,6 +7,7 @@ use std::ops::{Add, Mul, Neg};
 
 /// Normalised three dimensional real-number vector.
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[serde(transparent)]
 pub struct Dir3 {
     /// Internal data.
     data: Unit<Vector3<Real>>,

--- a/src/math/linalg/dir/dir3.rs
+++ b/src/math/linalg/dir/dir3.rs
@@ -185,7 +185,7 @@ impl Neg for Dir3 {
     type Output = Self;
 
     fn neg(self) -> Self::Output {
-        return Self::new(-self.x(), -self.y(), self.z());
+        return Self::new(-self.x(), -self.y(), -self.z());
     }
 }
 

--- a/src/math/linalg/dir/dir3.rs
+++ b/src/math/linalg/dir/dir3.rs
@@ -87,6 +87,12 @@ impl Dir3 {
 
     #[inline]
     #[must_use]
+    pub fn dot_vec(&self, b: &Vec3) -> f64 {
+        self.data.dot(&b.data())
+    }
+
+    #[inline]
+    #[must_use]
     pub fn renormalize(&mut self) {
         self.data.renormalize();
     }

--- a/src/math/linalg/dir/dir3.rs
+++ b/src/math/linalg/dir/dir3.rs
@@ -186,7 +186,7 @@ impl Mul<&Dir3> for f64 {
 impl Neg for Dir3 {
     type Output = Self;
 
-    /// Negation implementation for Dir3. 
+    /// Negation implementation for Dir3.
     #[inline]
     #[must_use]
     fn neg(self) -> Self::Output {
@@ -260,7 +260,7 @@ mod tests {
         assert_approx_eq!(-test_pos.y(), test_neg.y());
         assert_approx_eq!(-test_pos.z(), test_neg.z());
 
-        // Now test the inverse. 
+        // Now test the inverse.
         assert_approx_eq!(-test_neg.x(), test_pos.x());
         assert_approx_eq!(-test_neg.y(), test_pos.y());
         assert_approx_eq!(-test_neg.z(), test_pos.z());

--- a/src/math/linalg/dir/dir3.rs
+++ b/src/math/linalg/dir/dir3.rs
@@ -69,13 +69,13 @@ impl Dir3 {
 
     #[inline]
     #[must_use]
-    pub fn cross(&self, b: &Vec3) -> Vec3 {
+    pub fn cross_vec(&self, b: &Vec3) -> Vec3 {
         Vec3::from(self.data.cross(&b.data()))
     }
 
     #[inline]
     #[must_use]
-    pub fn cross_dir(&self, b: &Dir3) -> Vec3 {
+    pub fn cross(&self, b: &Dir3) -> Vec3 {
         Vec3::from(self.data.cross(&b.data()))
     }
 

--- a/src/math/linalg/dir/dir3.rs
+++ b/src/math/linalg/dir/dir3.rs
@@ -195,15 +195,29 @@ impl Neg for Dir3 {
 }
 
 impl Add<Dir3> for Dir3 {
-    type Output = Dir3;
+    type Output = Vec3;
 
     #[inline]
     #[must_use]
     fn add(self, rhs: Dir3) -> Self::Output {
-        Dir3::new(
+        Vec3::new(
             self.data.x + rhs.data.x,
             self.data.y + rhs.data.y,
             self.data.z + rhs.data.z,
+        )
+    }
+}
+
+impl Add<Vec3> for Dir3 {
+    type Output = Vec3;
+
+    #[inline]
+    #[must_use]
+    fn add(self, rhs: Vec3) -> Self::Output {
+        Vec3::new(
+            self.data.x + rhs.data().x,
+            self.data.y + rhs.data().y,
+            self.data.z + rhs.data().z,
         )
     }
 }

--- a/src/math/linalg/dir/dir4.rs
+++ b/src/math/linalg/dir/dir4.rs
@@ -6,6 +6,7 @@ use serde_derive::{Deserialize, Serialize};
 
 /// Normalised four dimensional real-number vector.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(transparent)]
 pub struct Dir4 {
     /// Internal data.
     data: Unit<Vector4<Real>>,

--- a/src/math/linalg/rot/rot2.rs
+++ b/src/math/linalg/rot/rot2.rs
@@ -1,4 +1,4 @@
-use nalgebra::{Rotation2};
+use nalgebra::Rotation2;
 use serde_derive::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/math/linalg/rot/rot2.rs
+++ b/src/math/linalg/rot/rot2.rs
@@ -1,5 +1,4 @@
-use crate::{core::Real, math::Vec2};
-use nalgebra::{Rotation2, Unit};
+use nalgebra::{Rotation2};
 use serde_derive::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/math/rng/probability.rs
+++ b/src/math/rng/probability.rs
@@ -14,17 +14,17 @@ use std::{
 };
 
 /// Probability distribution formulae.
-/// 
-/// This enum provides easy sampling from and manipulation of probability distribution functions (PDFs). 
-/// The most important function that this object serves is performing random sampling from PDFs. 
+///
+/// This enum provides easy sampling from and manipulation of probability distribution functions (PDFs).
+/// The most important function that this object serves is performing random sampling from PDFs.
 /// This enum supports a variety of different formulae:
 /// - `Probability::Point`: A constant value.
 /// - `Probability::Points`: Randomly sample one of a number of provided values.
-/// - `Probability::Linear`: Sample from a single linear spline. 
-/// - `Probability::Uniform`: Uniform probability between two values. 
-/// - `Probability::Gaussian`: A Gaussian (normal) distribution. 
-/// - `Probability::ConstantSpline`: Sample from a CDF whose value is determined by a `Formula`. 
-/// - `Probability::LinearSpline`: Sample from a PDF where an arbitrary dataset is represented by (N - 1) linear splines. 
+/// - `Probability::Linear`: Sample from a single linear spline.
+/// - `Probability::Uniform`: Uniform probability between two values.
+/// - `Probability::Gaussian`: A Gaussian (normal) distribution.
+/// - `Probability::ConstantSpline`: Sample from a CDF whose value is determined by a `Formula`.
+/// - `Probability::LinearSpline`: Sample from a PDF where an arbitrary dataset is represented by (N - 1) linear splines.
 
 #[derive(Clone, Debug)]
 pub enum Probability {
@@ -275,13 +275,12 @@ impl Probability {
         }
     }
 
-    /// Whereas the `sample` method performs random draws to sample from the distribution contained in the object, 
-    /// this method returns the value of the CDF at a given cumulative probability, effectively performing a manual sampling of the CDF. 
+    /// Whereas the `sample` method performs random draws to sample from the distribution contained in the object,
+    /// this method returns the value of the CDF at a given cumulative probability, effectively performing a manual sampling of the CDF.
     /// The input
     #[inline]
     #[must_use]
     pub fn sample_at(&self, ps: f64) -> f64 {
-
         match *self {
             Self::Point { ref c } => *c,
             Self::Points { ref cs } => cs[ps as usize],
@@ -294,7 +293,7 @@ impl Probability {
             } => {
                 debug_assert!(ps >= 0.0);
                 debug_assert!(ps <= 1.0);
-                
+
                 let r = ps;
                 ((2.0 * grad)
                     .mul_add(r.mul_add(area, offset), intercept * intercept)
@@ -348,8 +347,8 @@ impl Probability {
     }
 
     /// Outputs the PDF currently contained in this instance to a file at the provided path.
-    /// 
-    /// **Note:** this is only implemented for `LinearSpline` variants. 
+    ///
+    /// **Note:** this is only implemented for `LinearSpline` variants.
     #[inline]
     #[must_use]
     pub fn pdf_to_file(&self, filename: &str) -> Result<(), Error> {
@@ -378,8 +377,8 @@ impl Probability {
     }
 
     /// Outputs the CDF currently contained in this instance to a file at the provided path.
-    /// 
-    /// **Note:** this is only implemented for `LinearSpline` variants. 
+    ///
+    /// **Note:** this is only implemented for `LinearSpline` variants.
     #[inline]
     #[must_use]
     pub fn cdf_to_file(&self, filename: &str) -> Result<(), Error> {

--- a/src/math/rng/probability.rs
+++ b/src/math/rng/probability.rs
@@ -247,7 +247,7 @@ impl Probability {
                 ref offsets,
                 ref areas,
                 ref cdf,
-                ref xs,
+                xs: _,
             } => {
                 let a = rng.gen_range(0.0..1.0);
                 for (index, c) in cdf.iter().enumerate() {
@@ -309,7 +309,7 @@ impl Probability {
                 ref offsets,
                 ref areas,
                 ref cdf,
-                ref xs,
+                xs: _,
             } => {
                 debug_assert!(ps >= 0.0);
                 debug_assert!(ps <= 1.0);

--- a/src/math/stat/spherical_cdf.rs
+++ b/src/math/stat/spherical_cdf.rs
@@ -1,7 +1,6 @@
 use crate::{
     access,
     core::Real,
-    geom::ray,
     math::{linalg::Dir2, rng::Probability},
 };
 use cubic_splines;
@@ -9,7 +8,7 @@ use lidrs::photweb::{PhotometricWeb, PlaneWidth};
 use ndarray::Array1;
 use rand::Rng;
 use statrs::statistics::Statistics;
-use std::{f64::consts::PI, io::Write};
+use std::{f64::consts::PI};
 
 /// This is the target number of polar angles that we are aiming for for the spherical CDF.
 /// If more than this, we will not interpolate, however, if less we will interpolate data points
@@ -217,7 +216,7 @@ pub mod tests {
     use crate::data::Average;
     use assert_approx_eq::assert_approx_eq;
     use lidrs::photweb::{PhotometricWeb, Plane};
-    use std::{f64::consts::PI, io::Write};
+    use std::{f64::consts::PI};
 
     /// Tests that when we create an isotropic CDF we end up with a consistent outputs distribution
     /// from the sampling.

--- a/src/math/stat/spherical_cdf.rs
+++ b/src/math/stat/spherical_cdf.rs
@@ -8,7 +8,7 @@ use lidrs::photweb::{PhotometricWeb, PlaneWidth};
 use ndarray::Array1;
 use rand::Rng;
 use statrs::statistics::Statistics;
-use std::{f64::consts::PI};
+use std::f64::consts::PI;
 
 /// This is the target number of polar angles that we are aiming for for the spherical CDF.
 /// If more than this, we will not interpolate, however, if less we will interpolate data points
@@ -216,7 +216,7 @@ pub mod tests {
     use crate::data::Average;
     use assert_approx_eq::assert_approx_eq;
     use lidrs::photweb::{PhotometricWeb, Plane};
-    use std::{f64::consts::PI};
+    use std::f64::consts::PI;
 
     /// Tests that when we create an isotropic CDF we end up with a consistent outputs distribution
     /// from the sampling.

--- a/src/phys/mod.rs
+++ b/src/phys/mod.rs
@@ -5,6 +5,7 @@ pub mod light;
 pub mod local;
 pub mod material;
 pub mod photon;
+pub mod reflectance;
 
 // Builders
 pub mod light_linker_builder;
@@ -19,4 +20,5 @@ pub mod light_linker_builder_loader;
 pub use self::{
     crossing::*, light::*, light_linker::*, light_linker_builder::*,
     light_linker_builder_loader::*, local::*, material::*, material_builder::*, photon::*,
+    reflectance::*,
 };

--- a/src/phys/reflectance.rs
+++ b/src/phys/reflectance.rs
@@ -1,0 +1,174 @@
+use crate::{
+    core::Real,
+    fmt_report,
+    geom::{Hit, Ray},
+    math::{Dir3, Rot3, Trans3, Trans3Builder, Vec3},
+    sim::Attribute,
+};
+use rand::Rng;
+use serde::{Deserialize, Serialize};
+use std::{f64::consts::PI, fmt::Display};
+
+#[derive(Deserialize, Serialize, Clone)]
+pub enum Reflectance {
+    /// Lambertian Reflectance.
+    ///
+    /// Provides a purely diffuse reflectance, and reflects evenly in the hemisphere
+    /// around the normal vector, irrespective of the direction of the incident
+    /// light ray.
+    Lambertian { albedo: Real },
+    /// Specular Reflectance. (TODO)
+    Specular { albedo: Real },
+    /// Phong Reflectance. (TODO)
+    ///
+    /// A Phong reflectance model combines a combination of diffuse and specular reflectance.
+    Phong {
+        diffuse_albedo: Real,
+        specular_albedo: Real,
+    },
+}
+
+impl Reflectance {
+    /// Produces a new Lambertian reflectance instance.
+    pub fn new_lambertian(albedo: Real) -> Self {
+        Self::Lambertian { albedo }
+    }
+
+    /// Provided an incident ray, this will reflect the raw according to the
+    /// reflectance model that is used. Note that the returned ray can be an
+    /// option. In the case that `None` is returned, this is indicative that the
+    /// ray should not be reflected, and should be destroyed.
+    #[inline]
+    pub fn reflect<R: Rng>(
+        &self,
+        rng: &mut R,
+        incident_ray: &Ray,
+        hit: &Hit<Attribute>,
+    ) -> Option<Ray> {
+        match *self {
+            Self::Lambertian { ref albedo } => {
+                let should_reflect = rng.gen_range(0.0..1.0) < *albedo;
+
+                if should_reflect {
+                    let theta = rng.gen_range(0.0..2.0 * PI);
+                    let phi = rng.gen_range(-PI / 2.0..PI / 2.0);
+
+                    let mut reflected_ray =
+                        Ray::new(incident_ray.pos().clone(), hit.side().norm().clone());
+                    reflected_ray.rotate(phi, theta);
+                    Some(reflected_ray)
+                } else {
+                    None
+                }
+            }
+            _ => todo!(),
+        }
+    }
+}
+
+impl Display for Reflectance {
+    #[inline]
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match *self {
+            Self::Lambertian { ref albedo } => {
+                writeln!(fmt, "Lambertian: ")?;
+                fmt_report!(fmt, albedo, "albedo");
+                Ok(())
+            }
+            Self::Specular { ref albedo } => {
+                writeln!(fmt, "Specular: ")?;
+                fmt_report!(fmt, albedo, "albedo");
+                Ok(())
+            }
+            Self::Phong {
+                ref diffuse_albedo,
+                ref specular_albedo,
+            } => {
+                writeln!(fmt, "Phong: ")?;
+                fmt_report!(fmt, diffuse_albedo, "disffuse albedo");
+                fmt_report!(fmt, specular_albedo, "specular albedo");
+                Ok(())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Reflectance;
+    use std::f64::consts::PI;
+    use crate::{
+        geom::{Hit, Ray, Side},
+        math::{Dir3, Point3},
+        data::Histogram,
+        sim::Attribute, fs::Save,
+    };
+    use rand;
+
+    #[test]
+    fn test_lambertian_reflectance_perfect_reflector() {
+        // Create an incoming ray.
+        let incoming_ray = Ray::new(Point3::new(1., 1., 0.0), Dir3::new(-1.0, -1.0, 0.0));
+        let mut rng = rand::thread_rng();
+
+        // Simulate a hit on a surface.
+        let norm = Dir3::new(1.0, 1.0, 1.0);
+        let reflect = Reflectance::new_lambertian(1.0);
+        let attrib = Attribute::Reflector(reflect.clone());
+        let hit = Hit::new(&attrib, 1.0, Side::Outside(norm));
+
+        let mut phi_hist = Histogram::new(0.0, PI / 2.0, 180);
+        let theta_hist = Histogram::new(0.0, 2.0 * PI, 360);
+
+        let mut n_killed = 0;
+        for i in 0..10_000 {
+            match reflect.reflect(&mut rng, &incoming_ray, &hit) {
+                Some(ray) => {
+                    // Check that the outgoing ray is within the same hemisphere as the surface normal.
+                    // In the case of Lambertian scattering, this is a requirement.
+                    // The easy check for this is to check that norm · ray is positive.
+                    assert!(ray.dir().dot(&norm) > 0.0);
+
+                    // Sample the angle created by the ray from the normal.
+                    phi_hist.collect(ray.dir().dot(&norm).acos());
+                }
+                None => n_killed += 1,
+            }
+        }
+
+        // As the albedo is 1.0, there should be none killed.
+        assert_eq!(n_killed, 0);
+
+        // Check that the distribution of angles is correct.
+        phi_hist.save_data(std::path::Path::new("lambert_check.dat")).unwrap();
+    }
+
+    #[test]
+    fn test_lambertian_reflectance_semi_reflective() {
+        // Create an incoming ray.
+        let incoming_ray = Ray::new(Point3::new(1., 1., 0.0), Dir3::new(-1.0, -1.0, 0.0));
+        let mut rng = rand::thread_rng();
+
+        // Simulate a hit on a surface.
+        let norm = Dir3::new(1.0, 1.0, 1.0);
+        let reflect = Reflectance::new_lambertian(0.5);
+        let attrib = Attribute::Reflector(reflect.clone());
+        let hit = Hit::new(&attrib, 1.0, Side::Outside(norm));
+
+        let mut n_killed = 0;
+        for i in 0..10_000 {
+            match reflect.reflect(&mut rng, &incoming_ray, &hit) {
+                Some(ray) => {
+                    // Check that the outgoing ray is within the same hemisphere as the surface normal.
+                    // In the case of Lambertian scattering, this is a requirement.
+                    // The easy check for this is to check that norm · ray is positive.
+                    assert!(ray.dir().dot(&norm) > 0.0);
+                }
+                None => n_killed += 1,
+            }
+        }
+
+        // As the albedo is 0.5, we expect roughly half of the photons to get killed.
+        assert!(n_killed > 4900 && n_killed < 5100);
+    }
+}

--- a/src/phys/reflectance.rs
+++ b/src/phys/reflectance.rs
@@ -10,16 +10,19 @@ use std::{f64::consts::PI, fmt::Display};
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub enum Reflectance {
-    /// Lambertian Reflectance.
+    /// Lambertian Reflectance
     ///
     /// Provides a purely diffuse reflectance, and reflects evenly in the hemisphere
     /// around the normal vector, irrespective of the direction of the incident
     /// light ray.
     Lambertian { albedo: Real },
-    /// Specular Reflectance. (TODO)
+    /// Specular Reflectance
+    /// 
+    /// Provides a purely specular reflectance, where the angle of the reflected
+    /// photon from the normal vector is the same as the incoming ray. 
     Specular { albedo: Real },
-    /// Phong Reflectance. (TODO)
-    ///
+    /// Composition Reflectance Model - Specular + Diffuse
+    /// 
     /// A composite reflectance model combines a combination of diffuse and specular reflectance.
     /// The ratio between specular and diffuse reflection is determined by `specular_diffuse_ratio`. 
     Composite {
@@ -125,7 +128,7 @@ impl Display for Reflectance {
                 ref specular_albedo,
                 ref specular_diffuse_ratio,
             } => {
-                writeln!(fmt, "Phong: ")?;
+                writeln!(fmt, "Composite: ")?;
                 fmt_report!(fmt, diffuse_albedo, "diffuse albedo");
                 fmt_report!(fmt, specular_albedo, "specular albedo");
                 fmt_report!(fmt, specular_diffuse_ratio, "specular-to-diffuse ratio");

--- a/src/phys/reflectance.rs
+++ b/src/phys/reflectance.rs
@@ -9,7 +9,7 @@ use rand::Rng;
 use serde::{Deserialize, Serialize};
 use std::{f64::consts::PI, fmt::Display};
 
-#[derive(Deserialize, Serialize, Clone)]
+#[derive(Deserialize, Serialize, Clone, Debug)]
 pub enum Reflectance {
     /// Lambertian Reflectance.
     ///

--- a/src/phys/reflectance.rs
+++ b/src/phys/reflectance.rs
@@ -16,22 +16,22 @@ pub enum Reflectance {
     /// around the normal vector, irrespective of the direction of the incident
     /// light ray.
     /// The albdeo determines which portion of the incoming photons are reflected or killed.
-    /// An albedo of 1.0 will reflect all photons, and 0.0 will kill all photons. 
+    /// An albedo of 1.0 will reflect all photons, and 0.0 will kill all photons.
     Lambertian { albedo: Real },
     /// Specular Reflectance
-    /// 
+    ///
     /// Provides a purely specular reflectance, where the angle of the reflected
-    /// photon from the normal vector is the same as the incoming ray. 
+    /// photon from the normal vector is the same as the incoming ray.
     /// The albdeo determines which portion of the incoming photons are reflected or killed.
-    /// An albedo of 1.0 will reflect all photons, and 0.0 will kill all photons. 
+    /// An albedo of 1.0 will reflect all photons, and 0.0 will kill all photons.
     Specular { albedo: Real },
     /// Composition Reflectance Model - Specular + Diffuse
-    /// 
+    ///
     /// A composite reflectance model combines a combination of diffuse and specular reflectance.
-    /// The ratio between diffuse and soecular reflection is determined by `specular_diffuse_ratio`, 
-    /// with 1.0 corresponding to pure diffuse and 0.0 corresponding to pure specular. 
+    /// The ratio between diffuse and soecular reflection is determined by `specular_diffuse_ratio`,
+    /// with 1.0 corresponding to pure diffuse and 0.0 corresponding to pure specular.
     /// The `diffuse_albedo` and `specular_albedo` are directly fed through to the
-    /// albedos of their respective models and have their usual meanings. 
+    /// albedos of their respective models and have their usual meanings.
     Composite {
         diffuse_albedo: Real,
         specular_albedo: Real,
@@ -43,20 +43,20 @@ impl Reflectance {
     /// Produces a new Lambertian reflectance instance.
     /// This returns a purely diffuse reflection.
     /// In this case photons are randomly distributed in the hemisphere in which
-    /// the normal to the surface lies. 
+    /// the normal to the surface lies.
     /// The albdeo determines which portion of the incoming photons are reflected or killed.
-    /// An albedo of 1.0 will reflect all photons, and 0.0 will kill all photons. 
+    /// An albedo of 1.0 will reflect all photons, and 0.0 will kill all photons.
     pub fn new_lambertian(albedo: Real) -> Self {
         debug_assert!(albedo <= 1.0 && albedo >= 0.0);
 
         Self::Lambertian { albedo }
     }
 
-    /// Produces a new Specular reflectance instance. 
+    /// Produces a new Specular reflectance instance.
     /// This returns a purely specular reflection. In this case the incoming photons
     /// are reflected like they would be from a mirror; at the same angle to the normal vector of the surface.
     /// The albdeo determines which portion of the incoming photons are reflected or killed.
-    /// An albedo of 1.0 will reflect all photons, and 0.0 will kill all photons. 
+    /// An albedo of 1.0 will reflect all photons, and 0.0 will kill all photons.
     pub fn new_specular(albedo: Real) -> Self {
         debug_assert!(albedo <= 1.0 && albedo >= 0.0);
 
@@ -65,13 +65,21 @@ impl Reflectance {
 
     /// Prodduces a new Reflectance instance that is a composite between diffuse and specular reflection.
     /// This is a combination of diffuse (Lambertian) and specular reflection, with the ratio between them
-    /// determined by the `specular_diffuse_ratio`. 1.0 corresponds to pure diffuse and 0.0 corresponds to pure specular. 
-    pub fn new_composite(diffuse_albedo: Real, specular_albedo: Real, diffuse_specular_ratio: Real) -> Self {
+    /// determined by the `specular_diffuse_ratio`. 1.0 corresponds to pure diffuse and 0.0 corresponds to pure specular.
+    pub fn new_composite(
+        diffuse_albedo: Real,
+        specular_albedo: Real,
+        diffuse_specular_ratio: Real,
+    ) -> Self {
         debug_assert!(diffuse_albedo <= 1.0 && diffuse_albedo >= 0.0);
         debug_assert!(specular_albedo <= 1.0 && specular_albedo >= 0.0);
         debug_assert!(diffuse_specular_ratio <= 1.0 && diffuse_specular_ratio >= 0.0);
 
-        Self::Composite { diffuse_albedo, specular_albedo, diffuse_specular_ratio }
+        Self::Composite {
+            diffuse_albedo,
+            specular_albedo,
+            diffuse_specular_ratio,
+        }
     }
 
     /// Provided an incident ray, this will reflect the raw according to the
@@ -102,26 +110,31 @@ impl Reflectance {
                 } else {
                     None
                 }
-            },
-            Self:: Specular { ref albedo } => {
+            }
+            Self::Specular { ref albedo } => {
                 // This random draw determines if the photon should reflect, based on the value of the albedo.
                 let should_reflect = rng.gen_range(0.0..1.0) < *albedo;
 
                 if should_reflect {
                     // Implementation for this heavily borrowed from: https://www.cs.uaf.edu/2006/fall/cs381/lecture/10_03_specular.html
-                    let reflect = *incident_ray.dir() + 2.0 * hit.side().norm().dot(&-*incident_ray.dir()) * hit.side().norm();
+                    let reflect = *incident_ray.dir()
+                        + 2.0 * hit.side().norm().dot(&-*incident_ray.dir()) * hit.side().norm();
                     let reflected_ray = Ray::new(incident_ray.pos().clone(), reflect.into());
                     Some(reflected_ray)
                 } else {
                     None
                 }
-            },
-            Self::Composite { ref diffuse_albedo, ref specular_albedo, ref diffuse_specular_ratio } => {
+            }
+            Self::Composite {
+                ref diffuse_albedo,
+                ref specular_albedo,
+                ref diffuse_specular_ratio,
+            } => {
                 // This random draw determines, based on the ratio, whether the reflection for the
                 // current photon should be diffuse (Lambertian) or specular.
                 let is_specular = rng.gen_range(0.0..1.0) > *diffuse_specular_ratio;
 
-                // Then we just delegate handling of the reflection to the respective model. 
+                // Then we just delegate handling of the reflection to the respective model.
                 if is_specular {
                     Self::new_specular(*specular_albedo).reflect(rng, incident_ray, hit)
                 } else {
@@ -164,17 +177,17 @@ impl Display for Reflectance {
 #[cfg(test)]
 mod tests {
     use super::Reflectance;
-    use std::f64::consts::PI;
-    use assert_approx_eq::assert_approx_eq;
-    use statrs::statistics::Statistics;
     use crate::{
         core::Real,
-        geom::{Hit, Ray, Side},
-        math::{Dir3, Dir2, Point3},
         data::Histogram,
+        geom::{Hit, Ray, Side},
+        math::{Dir2, Dir3, Point3},
         sim::Attribute,
     };
+    use assert_approx_eq::assert_approx_eq;
     use rand;
+    use statrs::statistics::Statistics;
+    use std::f64::consts::PI;
 
     #[test]
     fn test_lambertian_reflectance_perfect_reflector() {
@@ -205,35 +218,37 @@ mod tests {
                     assert!(ray.dir().dot(&norm) > 0.0);
 
                     // Sample the angle created by the ray from the normal.
-                    phi_hist.collect(ray.dir().dot(&norm).acos()); 
-                    
-                    // Now sample the theta angle. 
+                    phi_hist.collect(ray.dir().dot(&norm).acos());
+
+                    // Now sample the theta angle.
                     let theta_dot = Dir2::new(ray.dir().x(), ray.dir().y()).dot(&surf_vec);
                     theta_hist.collect(theta_dot.acos());
                     // Just want to check that we are getting a uniform 360 degree coverage.
-                    // The dog product will only resolve to 0 -> pi radians. 
-                    if theta_dot < 0.0 { theta_dot_neg += 1; }
+                    // The dog product will only resolve to 0 -> pi radians.
+                    if theta_dot < 0.0 {
+                        theta_dot_neg += 1;
+                    }
                 }
                 None => n_killed += 1,
             }
         }
 
-        // Output for distributions. Uncomment to manually test / debug. 
+        // Output for distributions. Uncomment to manually test / debug.
         // phi_hist.save_data(std::path::Path::new("lambert_check.dat")).unwrap();
         // theta_hist.save_data(std::path::Path::new("lambert_check_theta.dat")).unwrap();
 
         // As the albedo is 1.0, there should be none killed.
         assert_eq!(n_killed, 0);
 
-        // Check that the phi distribution conforms to a cos(theta) fall off with angle.  
+        // Check that the phi distribution conforms to a cos(theta) fall off with angle.
         let norm_fac = phi_hist.iter().map(|(_b, c)| c).take(3).mean();
         for (bin, count) in phi_hist.iter() {
             // Assuming a generous threshold due to the relatively low number of photons and the nature of random draws.
-            // I don't want to be triggering off false positives left, right and centre.  
+            // I don't want to be triggering off false positives left, right and centre.
             assert_approx_eq!(bin.cos(), count / norm_fac as Real, 0.1);
         }
 
-        // Now check that the theta distribution is uniform. 
+        // Now check that the theta distribution is uniform.
         let theta_mean = theta_hist.iter().map(|(_b, c)| c).mean();
         for (_bin, count) in theta_hist.iter() {
             // Check that we are uniform to within
@@ -241,9 +256,12 @@ mod tests {
         }
 
         // Checkt hat we get roughly 50% of the dot products uniform, indicating
-        // theta coverage across both semi-circules. 
-        assert_approx_eq!(theta_dot_neg as Real, n_phot as Real * 0.5, n_phot as Real * 0.01);
-
+        // theta coverage across both semi-circules.
+        assert_approx_eq!(
+            theta_dot_neg as Real,
+            n_phot as Real * 0.5,
+            n_phot as Real * 0.01
+        );
     }
 
     #[test]
@@ -259,7 +277,7 @@ mod tests {
         let attrib = Attribute::Reflector(reflect.clone());
         let hit = Hit::new(&attrib, 1.0, Side::Outside(norm));
 
-        // Prepare bins for capturing statistics. 
+        // Prepare bins for capturing statistics.
         let mut phi_hist = Histogram::new(0.0, PI / 2.0, 90);
         let mut theta_hist = Histogram::new(0.0, PI, 18);
 
@@ -276,34 +294,40 @@ mod tests {
 
                     // Sample the angle created by the ray from the normal.
                     phi_hist.collect(ray.dir().dot(&norm).acos());
-                    
-                    // Now sample the theta angle. 
+
+                    // Now sample the theta angle.
                     let theta_dot = Dir2::new(ray.dir().x(), ray.dir().y()).dot(&surf_vec);
                     theta_hist.collect(theta_dot.acos());
                     // Just want to check that we are getting a uniform 360 degree coverage.
-                    // The dog product will only resolve to 0 -> pi radians. 
-                    if theta_dot < 0.0 { theta_dot_neg += 1; }
+                    // The dog product will only resolve to 0 -> pi radians.
+                    if theta_dot < 0.0 {
+                        theta_dot_neg += 1;
+                    }
                 }
                 None => n_killed += 1,
             }
         }
 
-        // Output for distributions. Uncomment to manually test / debug. 
+        // Output for distributions. Uncomment to manually test / debug.
         // phi_hist.save_data(std::path::Path::new("lambert_check.dat")).unwrap();
         // theta_hist.save_data(std::path::Path::new("lambert_check_theta.dat")).unwrap();
 
         // As the albedo is 0.5, we expect roughly half of the photons to get killed.
-        assert_approx_eq!(n_killed as Real, n_phot as Real * 0.5, n_phot as Real * 0.01);
+        assert_approx_eq!(
+            n_killed as Real,
+            n_phot as Real * 0.5,
+            n_phot as Real * 0.01
+        );
 
-        // Check that the phi distribution conforms to a cos(theta) fall off with angle.  
+        // Check that the phi distribution conforms to a cos(theta) fall off with angle.
         let norm_fac = phi_hist.iter().map(|(_b, c)| c).take(3).mean();
         for (bin, count) in phi_hist.iter() {
             // Assuming a generous threshold due to the relatively low number of photons and the nature of random draws.
-            // I don't want to be triggering off false positives left, right and centre.  
+            // I don't want to be triggering off false positives left, right and centre.
             assert_approx_eq!(bin.cos(), count / norm_fac as Real, 0.15);
         }
 
-        // Now check that the theta distribution is uniform. 
+        // Now check that the theta distribution is uniform.
         let theta_mean = theta_hist.iter().map(|(_b, c)| c).mean();
         for (_bin, count) in theta_hist.iter() {
             // Check that we are uniform to within
@@ -311,12 +335,16 @@ mod tests {
         }
 
         // Checkt hat we get roughly 50% of the dot products uniform, indicating
-        // theta coverage across both semi-circules. 
-        assert_approx_eq!(theta_dot_neg as Real, (n_phot - n_killed) as Real * 0.5, (n_phot - n_killed) as Real * 0.01);
+        // theta coverage across both semi-circules.
+        assert_approx_eq!(
+            theta_dot_neg as Real,
+            (n_phot - n_killed) as Real * 0.5,
+            (n_phot - n_killed) as Real * 0.01
+        );
     }
 
     /// This is a test of the specular reflection code. This should be a lot easier
-    /// than the diffuse tests. As we know the incoming ray, and normal vector, 
+    /// than the diffuse tests. As we know the incoming ray, and normal vector,
     /// we can analytically find the reflected ray.
     #[test]
     fn test_specular_reflectance_perfect_reflector() {
@@ -330,15 +358,15 @@ mod tests {
         let attrib = Attribute::Reflector(reflect.clone());
         let hit = Hit::new(&attrib, 2.0_f64.sqrt(), Side::Outside(norm));
 
-        // Expected output - analytically determined by working through the equations. 
+        // Expected output - analytically determined by working through the equations.
         let reflected_ray_test = Ray::new(Point3::new(1.0, 0.0, 1.0), Dir3::new(1.0, 0.0, 1.0));
 
         match reflect.reflect(&mut rng, &incoming_ray, &hit) {
             Some(ray) => {
-                // Use assert_approx_eq due to numerical noise. 
+                // Use assert_approx_eq due to numerical noise.
                 assert_approx_eq!(ray.dir().dot(reflected_ray_test.dir()), 1.0);
-            },
-            None => assert!(false), // With a perfect reflector, we should have no killed photons. 
+            }
+            None => assert!(false), // With a perfect reflector, we should have no killed photons.
         }
     }
 
@@ -354,25 +382,29 @@ mod tests {
         let attrib = Attribute::Reflector(reflect.clone());
         let hit = Hit::new(&attrib, 2.0_f64.sqrt(), Side::Outside(norm));
 
-        // Expected output - analytically determined by working through the equations. 
+        // Expected output - analytically determined by working through the equations.
         let reflected_ray_test = Ray::new(Point3::new(1.0, 0.0, 1.0), Dir3::new(1.0, 0.0, 1.0));
 
-        // Register killed photons. 
+        // Register killed photons.
         let n_photon: usize = 100_000;
         let mut n_killed_photons: usize = 0;
         for _ in 0..n_photon {
             match reflect.reflect(&mut rng, &incoming_ray, &hit) {
                 Some(ray) => {
-                    // Use assert_approx_eq due to numerical noise. 
+                    // Use assert_approx_eq due to numerical noise.
                     assert_approx_eq!(ray.dir().dot(reflected_ray_test.dir()), 1.0);
-                },
-                None => n_killed_photons += 1, // With a perfect reflector, we should have no killed photons. 
+                }
+                None => n_killed_photons += 1, // With a perfect reflector, we should have no killed photons.
             }
         }
 
-        // Now check that the kill-rate of photons is consistent with the albedo. 
+        // Now check that the kill-rate of photons is consistent with the albedo.
         println!("{}", n_killed_photons);
-        assert_approx_eq!(n_killed_photons as Real, n_photon as Real * 0.5, n_photon as Real * 0.01);
+        assert_approx_eq!(
+            n_killed_photons as Real,
+            n_photon as Real * 0.5,
+            n_photon as Real * 0.01
+        );
     }
 
     #[test]
@@ -388,7 +420,7 @@ mod tests {
         let attrib = Attribute::Reflector(reflect.clone());
         let hit = Hit::new(&attrib, 2.0_f64.sqrt(), Side::Outside(norm));
 
-        // Prepare bins for capturing statistics. 
+        // Prepare bins for capturing statistics.
         let mut phi_hist = Histogram::new(0.0, PI / 2.0, 90);
         let mut theta_hist = Histogram::new(0.0, PI, 180);
 
@@ -404,50 +436,67 @@ mod tests {
 
                     // Sample the angle created by the ray from the normal.
                     phi_hist.collect(ray.dir().dot(&norm).acos());
-                    
-                    // Now sample the theta angle. 
+
+                    // Now sample the theta angle.
                     let theta_dot = Dir2::new(ray.dir().x(), ray.dir().y()).dot(&surf_vec);
                     theta_hist.collect(theta_dot.acos());
                     // Just want to check that we are getting a uniform 360 degree coverage.
-                    // The dog product will only resolve to 0 -> pi radians. 
-                    if theta_dot < 0.0 { theta_dot_neg += 1; }
+                    // The dog product will only resolve to 0 -> pi radians.
+                    if theta_dot < 0.0 {
+                        theta_dot_neg += 1;
+                    }
                 }
                 None => assert!(false),
             }
         }
 
-        // Output for distributions. Uncomment to manually test / debug. 
+        // Output for distributions. Uncomment to manually test / debug.
         // phi_hist.save_data(std::path::Path::new("composite_check.dat")).unwrap();
         // theta_hist.save_data(std::path::Path::new("composite_check_theta.dat")).unwrap();
 
         // Initialise our models for comparison.
-        // The specular model is consistent between the theta and phi axes as it 
-        // manifests as a constant n_photon / 2 term that occurs in a single bin. 
-        let specular_component = |ibin: usize, target_bin: usize, nphot: usize, ratio: Real, albedo: Real| { if ibin == target_bin { nphot as Real * albedo * ratio } else {0.0}};
+        // The specular model is consistent between the theta and phi axes as it
+        // manifests as a constant n_photon / 2 term that occurs in a single bin.
+        let specular_component =
+            |ibin: usize, target_bin: usize, nphot: usize, ratio: Real, albedo: Real| {
+                if ibin == target_bin {
+                    nphot as Real * albedo * ratio
+                } else {
+                    0.0
+                }
+            };
         // The diffuse component is more complicated as in theta it merely dilutes
         // the the entire n_photon / 2 allocation over all bins in the histogram.
         // However in the phi component there is a cos(phi) dependence, which we
-        // model by borrowing the method from out lambertian reflectance tests above. 
+        // model by borrowing the method from out lambertian reflectance tests above.
         let diff_norm_fac_phi = phi_hist.iter().map(|(_b, c)| c).take(3).mean();
-        let diffuse_component_phi = |bin: Real, norm_fac: Real| { bin.cos() * norm_fac };
-        let diffuse_component_theta = |nbin: usize, nphot: usize, ratio: Real, albedo: Real| { (albedo * nphot as Real * ratio) / nbin as Real };
+        let diffuse_component_phi = |bin: Real, norm_fac: Real| bin.cos() * norm_fac;
+        let diffuse_component_theta = |nbin: usize, nphot: usize, ratio: Real, albedo: Real| {
+            (albedo * nphot as Real * ratio) / nbin as Real
+        };
 
         for (ibin, (bin, count)) in phi_hist.iter().enumerate() {
-            // The bins are at 1 degree increments. As we are testing relative to the x-axis, the reflection should be at 90 degrees, and hence should be in the 90th bin. 
-            let model_count = diffuse_component_phi(bin, diff_norm_fac_phi) + specular_component(ibin, 45, n_phot, 0.5, 1.0);
+            // The bins are at 1 degree increments. As we are testing relative to the x-axis, the reflection should be at 90 degrees, and hence should be in the 90th bin.
+            let model_count = diffuse_component_phi(bin, diff_norm_fac_phi)
+                + specular_component(ibin, 45, n_phot, 0.5, 1.0);
             // We are checking that we agree to about the 1% level.
             assert_approx_eq!(model_count, count, n_phot as Real * 0.01);
         }
 
         for (ibin, (_, count)) in theta_hist.iter().enumerate() {
-            // The bins are at 1 degree increments. As we are testing relative to the x-axis, the reflection should be at 90 degrees, and hence should be in the 90th bin. 
-            let model_count = diffuse_component_theta(theta_hist.binner().bins(), n_phot, 0.5, 1.0) + specular_component(ibin, 90, n_phot, 0.5, 1.0);
+            // The bins are at 1 degree increments. As we are testing relative to the x-axis, the reflection should be at 90 degrees, and hence should be in the 90th bin.
+            let model_count = diffuse_component_theta(theta_hist.binner().bins(), n_phot, 0.5, 1.0)
+                + specular_component(ibin, 90, n_phot, 0.5, 1.0);
             // We are checking that we agree to about the 1% level.
             assert_approx_eq!(model_count, count, n_phot as Real * 0.01);
         }
 
         // Checkt hat we get roughly 25% of the dot products uniform, indicating
-        // theta coverage across both semi-circules. 
-        assert_approx_eq!(theta_dot_neg as Real, n_phot as Real * 0.25, n_phot as Real * 0.01);
+        // theta coverage across both semi-circules.
+        assert_approx_eq!(
+            theta_dot_neg as Real,
+            n_phot as Real * 0.25,
+            n_phot as Real * 0.01
+        );
     }
 }

--- a/src/phys/reflectance.rs
+++ b/src/phys/reflectance.rs
@@ -51,7 +51,8 @@ impl Reflectance {
 
                 if should_reflect {
                     let theta = rng.gen_range(0.0..2.0 * PI);
-                    let phi = rng.gen_range(-PI / 2.0..PI / 2.0);
+                    // We sample the phi angle using PDF = sin(theta)
+                    let phi = (rng.gen_range(0.0..1.0) as Real).asin();
 
                     let mut reflected_ray =
                         Ray::new(incident_ray.pos().clone(), hit.side().norm().clone());
@@ -117,11 +118,11 @@ mod tests {
         let attrib = Attribute::Reflector(reflect.clone());
         let hit = Hit::new(&attrib, 1.0, Side::Outside(norm));
 
-        let mut phi_hist = Histogram::new(0.0, PI / 2.0, 180);
-        let theta_hist = Histogram::new(0.0, 2.0 * PI, 360);
+        let mut phi_hist = Histogram::new(0.0, PI / 2.0, 90);
+        let theta_hist = Histogram::new(0.0, 2.0 * PI, 36);
 
         let mut n_killed = 0;
-        for i in 0..10_000 {
+        for _ in 0..10_000 {
             match reflect.reflect(&mut rng, &incoming_ray, &hit) {
                 Some(ray) => {
                     // Check that the outgoing ray is within the same hemisphere as the surface normal.

--- a/src/sim/attribute/attribute.rs
+++ b/src/sim/attribute/attribute.rs
@@ -1,6 +1,6 @@
 //! Optical attributes.
 
-use crate::{fmt_report, geom::Orient, phys::Material, tools::Binner};
+use crate::{fmt_report, geom::Orient, phys::Material, phys::Reflectance, tools::Binner};
 use std::fmt::{Display, Error, Formatter};
 
 /// Surface attributes.
@@ -15,6 +15,8 @@ pub enum Attribute<'a> {
     Imager(usize, f64, Orient),
     /// CCD detector id, width, orientation, binner.
     Ccd(usize, f64, Orient, Binner),
+    /// A purely reflecting material, with a provided reflectance model.
+    Reflector(Reflectance),
 }
 
 impl Display for Attribute<'_> {
@@ -43,6 +45,11 @@ impl Display for Attribute<'_> {
                 fmt_report!(fmt, width, "width (m)");
                 fmt_report!(fmt, orient, "orientation");
                 fmt_report!(fmt, binner, "binner (m)");
+                Ok(())
+            }
+            Self::Reflector(ref reflectance) => {
+                writeln!(fmt, "Reflector: ...")?;
+                fmt_report!(fmt, reflectance, "reflectance");
                 Ok(())
             }
         }

--- a/src/sim/attribute/attribute_linker.rs
+++ b/src/sim/attribute/attribute_linker.rs
@@ -6,9 +6,9 @@ use crate::{
     geom::Orient,
     ord::{Link, Name, Set},
     phys::Material,
+    phys::Reflectance,
     sim::attribute::Attribute,
     tools::Binner,
-    phys::Reflectance, 
 };
 use std::fmt::{Display, Formatter};
 
@@ -35,7 +35,11 @@ impl<'a> Link<'a, Material> for AttributeLinker {
     fn requires(&self) -> Vec<Name> {
         match *self {
             Self::Interface(ref inside, ref outside) => vec![inside.clone(), outside.clone()],
-            Self::Mirror(..) | Self::Spectrometer(..) | Self::Imager(..) | Self::Ccd(..) | Self::Reflector(..) => {
+            Self::Mirror(..)
+            | Self::Spectrometer(..)
+            | Self::Imager(..)
+            | Self::Ccd(..)
+            | Self::Reflector(..) => {
                 vec![]
             }
         }

--- a/src/sim/attribute/attribute_linker.rs
+++ b/src/sim/attribute/attribute_linker.rs
@@ -8,6 +8,7 @@ use crate::{
     phys::Material,
     sim::attribute::Attribute,
     tools::Binner,
+    phys::Reflectance, 
 };
 use std::fmt::{Display, Formatter};
 
@@ -23,6 +24,8 @@ pub enum AttributeLinker {
     Imager(usize, f64, Orient),
     /// CCD detector id, width, orientation, binner.
     Ccd(usize, f64, Orient, Binner),
+    /// A purely reflecting material, with a provided reflectance model.
+    Reflector(Reflectance),
 }
 
 impl<'a> Link<'a, Material> for AttributeLinker {
@@ -32,7 +35,7 @@ impl<'a> Link<'a, Material> for AttributeLinker {
     fn requires(&self) -> Vec<Name> {
         match *self {
             Self::Interface(ref inside, ref outside) => vec![inside.clone(), outside.clone()],
-            Self::Mirror(..) | Self::Spectrometer(..) | Self::Imager(..) | Self::Ccd(..) => {
+            Self::Mirror(..) | Self::Spectrometer(..) | Self::Imager(..) | Self::Ccd(..) | Self::Reflector(..) => {
                 vec![]
             }
         }
@@ -53,6 +56,7 @@ impl<'a> Link<'a, Material> for AttributeLinker {
             Self::Spectrometer(id) => Self::Inst::Spectrometer(id),
             Self::Imager(id, width, orient) => Self::Inst::Imager(id, width, orient),
             Self::Ccd(id, width, orient, binner) => Self::Inst::Ccd(id, width, orient, binner),
+            Self::Reflector(reflectance) => Self::Inst::Reflector(reflectance),
         })
     }
 }
@@ -83,6 +87,11 @@ impl Display for AttributeLinker {
                 fmt_report!(fmt, width, "width (m)");
                 fmt_report!(fmt, orient, "orientation");
                 fmt_report!(fmt, binner, "binner");
+                Ok(())
+            }
+            Self::Reflector(ref reflectance) => {
+                writeln!(fmt, "Reflector: ...")?;
+                fmt_report!(fmt, reflectance, "reflectance");
                 Ok(())
             }
         }

--- a/src/sim/attribute/attribute_linker_linker.rs
+++ b/src/sim/attribute/attribute_linker_linker.rs
@@ -7,6 +7,7 @@ use crate::{
     ord::{Link, Name, Set},
     sim::attribute::AttributeLinker,
     tools::{Binner, Range},
+    phys::Reflectance,
 };
 use std::fmt::{Display, Formatter};
 
@@ -23,6 +24,8 @@ pub enum AttributeLinkerLinker {
     Imager(usize, f64, Orient),
     /// CCD detector id, width, orientation, binner.
     Ccd(usize, f64, Orient, Binner),
+    /// A purely reflecting material, with a provided reflectance model.
+    Reflector(Reflectance),
 }
 
 impl<'a> Link<'a, usize> for AttributeLinkerLinker {
@@ -44,6 +47,8 @@ impl<'a> Link<'a, usize> for AttributeLinkerLinker {
             ),
             Self::Imager(id, width, orient) => Self::Inst::Imager(id, width, orient),
             Self::Ccd(id, width, orient, binner) => Self::Inst::Ccd(id, width, orient, binner),
+            Self::Reflector(reflectance) => Self::Inst::Reflector(reflectance),
+            Self::Reflector(reflectance) => Self::Inst::Reflector(reflectance),
         })
     }
 }
@@ -80,6 +85,16 @@ impl Display for AttributeLinkerLinker {
                 fmt_report!(fmt, width, "width (m)");
                 fmt_report!(fmt, orient, "orientation");
                 fmt_report!(fmt, binner, "binner");
+                Ok(())
+            }
+            Self::Reflector(ref reflectance) => {
+                writeln!(fmt, "Reflector: ...")?;
+                fmt_report!(fmt, reflectance, "reflectance");
+                Ok(())
+            }
+            Self::Reflector(ref reflectance) => {
+                writeln!(fmt, "Reflector: ...")?;
+                fmt_report!(fmt, reflectance, "reflectance");
                 Ok(())
             }
         }

--- a/src/sim/attribute/attribute_linker_linker.rs
+++ b/src/sim/attribute/attribute_linker_linker.rs
@@ -48,7 +48,6 @@ impl<'a> Link<'a, usize> for AttributeLinkerLinker {
             Self::Imager(id, width, orient) => Self::Inst::Imager(id, width, orient),
             Self::Ccd(id, width, orient, binner) => Self::Inst::Ccd(id, width, orient, binner),
             Self::Reflector(reflectance) => Self::Inst::Reflector(reflectance),
-            Self::Reflector(reflectance) => Self::Inst::Reflector(reflectance),
         })
     }
 }
@@ -85,11 +84,6 @@ impl Display for AttributeLinkerLinker {
                 fmt_report!(fmt, width, "width (m)");
                 fmt_report!(fmt, orient, "orientation");
                 fmt_report!(fmt, binner, "binner");
-                Ok(())
-            }
-            Self::Reflector(ref reflectance) => {
-                writeln!(fmt, "Reflector: ...")?;
-                fmt_report!(fmt, reflectance, "reflectance");
                 Ok(())
             }
             Self::Reflector(ref reflectance) => {

--- a/src/sim/attribute/attribute_linker_linker.rs
+++ b/src/sim/attribute/attribute_linker_linker.rs
@@ -5,9 +5,9 @@ use crate::{
     fmt_report,
     geom::Orient,
     ord::{Link, Name, Set},
+    phys::Reflectance,
     sim::attribute::AttributeLinker,
     tools::{Binner, Range},
-    phys::Reflectance,
 };
 use std::fmt::{Display, Formatter};
 

--- a/src/sim/attribute/attribute_linker_linker_linker.rs
+++ b/src/sim/attribute/attribute_linker_linker_linker.rs
@@ -8,6 +8,7 @@ use crate::{
     ord::{Link, Name, Set, X, Y},
     sim::attribute::AttributeLinkerLinker,
     tools::{Binner, Range},
+    phys::{Reflectance, reflectance},
 };
 use std::fmt::{Display, Formatter};
 
@@ -24,6 +25,8 @@ pub enum AttributeLinkerLinkerLinker {
     Imager(Name, [usize; 2], f64, Point3, Vec3),
     /// CCD detector id, width, orientation, binner.
     Ccd(usize, f64, Orient, Binner),
+    /// A purely reflecting material, with a provided reflectance model.
+    Reflector(Reflectance),
 }
 
 impl<'a> Link<'a, usize> for AttributeLinkerLinkerLinker {
@@ -49,6 +52,7 @@ impl<'a> Link<'a, usize> for AttributeLinkerLinkerLinker {
                 Orient::new(Ray::new(center, Dir3::from(forward))),
             ),
             Self::Ccd(id, width, orient, binner) => Self::Inst::Ccd(id, width, orient, binner),
+            Self::Reflector(reflectance) => Self::Inst::Reflector(reflectance)
         })
     }
 }
@@ -87,6 +91,11 @@ impl Display for AttributeLinkerLinkerLinker {
                 fmt_report!(fmt, width, "width (m)");
                 fmt_report!(fmt, orient, "orientation");
                 fmt_report!(fmt, binner, "binner");
+                Ok(())
+            }
+            Self::Reflector(ref reflectance) => {
+                writeln!(fmt, "Reflector: ...")?;
+                fmt_report!(fmt, reflectance, "reflectance");
                 Ok(())
             }
         }

--- a/src/sim/attribute/attribute_linker_linker_linker.rs
+++ b/src/sim/attribute/attribute_linker_linker_linker.rs
@@ -6,9 +6,9 @@ use crate::{
     geom::{Orient, Ray},
     math::{Dir3, Point3, Vec3},
     ord::{Link, Name, Set, X, Y},
+    phys::Reflectance,
     sim::attribute::AttributeLinkerLinker,
     tools::{Binner, Range},
-    phys::{Reflectance},
 };
 use std::fmt::{Display, Formatter};
 
@@ -52,7 +52,7 @@ impl<'a> Link<'a, usize> for AttributeLinkerLinkerLinker {
                 Orient::new(Ray::new(center, Dir3::from(forward))),
             ),
             Self::Ccd(id, width, orient, binner) => Self::Inst::Ccd(id, width, orient, binner),
-            Self::Reflector(reflectance) => Self::Inst::Reflector(reflectance)
+            Self::Reflector(reflectance) => Self::Inst::Reflector(reflectance),
         })
     }
 }

--- a/src/sim/attribute/attribute_linker_linker_linker.rs
+++ b/src/sim/attribute/attribute_linker_linker_linker.rs
@@ -8,7 +8,7 @@ use crate::{
     ord::{Link, Name, Set, X, Y},
     sim::attribute::AttributeLinkerLinker,
     tools::{Binner, Range},
-    phys::{Reflectance, reflectance},
+    phys::{Reflectance},
 };
 use std::fmt::{Display, Formatter};
 

--- a/src/sim/attribute/attribute_linker_linker_linker_linker.rs
+++ b/src/sim/attribute/attribute_linker_linker_linker_linker.rs
@@ -29,7 +29,7 @@ pub enum AttributeLinkerLinkerLinkerLinker {
     Ccd(Name, [usize; 2], f64, Point3, Vec3, Binner),
     /// A purely reflecting material, with a provided reflectance model.
     /// The first coefficient is diffuse albedo, the second is specular. 
-    Reflector(f64, f64),
+    Reflector(f64, f64, f64),
 }
 
 impl<'a> Link<'a, usize> for AttributeLinkerLinkerLinkerLinker {
@@ -58,10 +58,10 @@ impl<'a> Link<'a, usize> for AttributeLinkerLinkerLinkerLinker {
                 Orient::new(Ray::new(center, Dir3::from(forward))),
                 binner,
             ),
-            Self::Reflector(diff_alb, spec_alb) => {
+            Self::Reflector(diff_alb, spec_alb, spec_diff_ratio) => {
                 let ref_model = if diff_alb > 0.0 {
                     if spec_alb > 0.0 {
-                        Reflectance::Phong { diffuse_albedo: diff_alb, specular_albedo: spec_alb }
+                        Reflectance::Composite { diffuse_albedo: diff_alb, specular_albedo: spec_alb, specular_diffuse_ratio: spec_diff_ratio }
                     } else {
                         Reflectance::Lambertian { albedo: diff_alb }
                     }
@@ -113,10 +113,11 @@ impl Display for AttributeLinkerLinkerLinkerLinker {
                 fmt_report!(fmt, binner, "binner");
                 Ok(())
             }
-            Self::Reflector(ref diff_alb, ref spec_alb) => {
+            Self::Reflector(ref diff_alb, ref spec_alb, ref spec_diff_ratio) => {
                 writeln!(fmt, "Reflector: ...")?;
                 fmt_report!(fmt, diff_alb, "diffuse albedo");
                 fmt_report!(fmt, spec_alb, "specular albedo");
+                fmt_report!(fmt, spec_diff_ratio, "specular-to-diffuse ratio");
                 Ok(())
             }
         }

--- a/src/sim/attribute/attribute_linker_linker_linker_linker.rs
+++ b/src/sim/attribute/attribute_linker_linker_linker_linker.rs
@@ -6,8 +6,8 @@ use crate::{
     geom::{Orient, Ray},
     math::{Dir3, Point3, Vec3},
     ord::{Link, Name, Set, X, Y},
-    sim::{attribute::AttributeLinkerLinkerLinker},
     phys::Reflectance,
+    sim::attribute::AttributeLinkerLinkerLinker,
     tools::{Binner, Range},
 };
 use arctk_attr::file;
@@ -28,7 +28,7 @@ pub enum AttributeLinkerLinkerLinkerLinker {
     /// Imager id, resolution, horizontal width (m), center, forward direction, wavelength binner (m).
     Ccd(Name, [usize; 2], f64, Point3, Vec3, Binner),
     /// A purely reflecting material, with a provided reflectance model.
-    /// The first coefficient is diffuse albedo, the second is specular. 
+    /// The first coefficient is diffuse albedo, the second is specular.
     Reflector(f64, f64, f64),
 }
 
@@ -61,16 +61,20 @@ impl<'a> Link<'a, usize> for AttributeLinkerLinkerLinkerLinker {
             Self::Reflector(diff_alb, spec_alb, diff_spec_ratio) => {
                 let ref_model = if diff_alb > 0.0 {
                     if spec_alb > 0.0 {
-                        Reflectance::Composite { diffuse_albedo: diff_alb, specular_albedo: spec_alb, diffuse_specular_ratio: diff_spec_ratio }
+                        Reflectance::Composite {
+                            diffuse_albedo: diff_alb,
+                            specular_albedo: spec_alb,
+                            diffuse_specular_ratio: diff_spec_ratio,
+                        }
                     } else {
                         Reflectance::Lambertian { albedo: diff_alb }
                     }
                 } else {
                     Reflectance::Specular { albedo: spec_alb }
-                }; 
+                };
 
                 Self::Inst::Reflector(ref_model)
-            },
+            }
         })
     }
 }

--- a/src/sim/attribute/attribute_linker_linker_linker_linker.rs
+++ b/src/sim/attribute/attribute_linker_linker_linker_linker.rs
@@ -58,10 +58,10 @@ impl<'a> Link<'a, usize> for AttributeLinkerLinkerLinkerLinker {
                 Orient::new(Ray::new(center, Dir3::from(forward))),
                 binner,
             ),
-            Self::Reflector(diff_alb, spec_alb, spec_diff_ratio) => {
+            Self::Reflector(diff_alb, spec_alb, diff_spec_ratio) => {
                 let ref_model = if diff_alb > 0.0 {
                     if spec_alb > 0.0 {
-                        Reflectance::Composite { diffuse_albedo: diff_alb, specular_albedo: spec_alb, specular_diffuse_ratio: spec_diff_ratio }
+                        Reflectance::Composite { diffuse_albedo: diff_alb, specular_albedo: spec_alb, diffuse_specular_ratio: diff_spec_ratio }
                     } else {
                         Reflectance::Lambertian { albedo: diff_alb }
                     }
@@ -113,11 +113,11 @@ impl Display for AttributeLinkerLinkerLinkerLinker {
                 fmt_report!(fmt, binner, "binner");
                 Ok(())
             }
-            Self::Reflector(ref diff_alb, ref spec_alb, ref spec_diff_ratio) => {
+            Self::Reflector(ref diff_alb, ref spec_alb, ref diff_spec_ratio) => {
                 writeln!(fmt, "Reflector: ...")?;
                 fmt_report!(fmt, diff_alb, "diffuse albedo");
                 fmt_report!(fmt, spec_alb, "specular albedo");
-                fmt_report!(fmt, spec_diff_ratio, "specular-to-diffuse ratio");
+                fmt_report!(fmt, diff_spec_ratio, "diffuse-to-specular ratio");
                 Ok(())
             }
         }

--- a/src/sim/peel_off.rs
+++ b/src/sim/peel_off.rs
@@ -71,7 +71,8 @@ pub fn peel_off(input: &Input, mut phot: Photon, env: &Local, pos: Point3) -> Op
                 Attribute::Mirror(..)
                 | Attribute::Spectrometer(..)
                 | Attribute::Imager(..)
-                | Attribute::Ccd(..) => return None,
+                | Attribute::Ccd(..)
+                | Attribute::Reflector(..) => return None,
             }
         } else {
             prob *= (-tar_dist * inter_coeff).exp();

--- a/src/sim/surface.rs
+++ b/src/sim/surface.rs
@@ -95,12 +95,10 @@ pub fn surface(
 
             phot.kill();
         }
-        Attribute::Reflector(ref reflectance) => {
-            match reflectance.reflect(rng, phot.ray(), hit) {
-                Some(ray) => *phot.ray_mut() = ray,
-                None => phot.kill(),
-            }
-        }
+        Attribute::Reflector(ref reflectance) => match reflectance.reflect(rng, phot.ray(), hit) {
+            Some(ray) => *phot.ray_mut() = ray,
+            None => phot.kill(),
+        },
     }
 }
 

--- a/src/sim/surface.rs
+++ b/src/sim/surface.rs
@@ -95,6 +95,10 @@ pub fn surface(
 
             phot.kill();
         }
+        Attribute::Reflector(ref reflectance) => {
+            // TODO: Implement the reflection code for a ray hitting a surface. 
+            todo!()
+        }
     }
 }
 

--- a/src/sim/surface.rs
+++ b/src/sim/surface.rs
@@ -4,7 +4,7 @@ use crate::{
     geom::Hit,
     img::Colour,
     ord::{X, Y},
-    phys::{Crossing, Local, Photon, Reflectance},
+    phys::{Crossing, Local, Photon},
     sim::{Attribute, Output},
 };
 use rand::{rngs::ThreadRng, Rng};
@@ -96,16 +96,9 @@ pub fn surface(
             phot.kill();
         }
         Attribute::Reflector(ref reflectance) => {
-            // TODO: Implement the reflection code for a ray hitting a surface. 
-
-            match reflectance {
-                Reflectance::Lambertian { albedo: _ } | Reflectance::Specular { albedo: _ } | Reflectance::Composite { diffuse_albedo: _,  specular_albedo: _, specular_diffuse_ratio: _}  => {
-                    match reflectance.reflect(rng, phot.ray(), hit) {
-                        Some(ray) => *phot.ray_mut() = ray,
-                        None => phot.kill(),
-                    }
-                },
-                _ => todo!()
+            match reflectance.reflect(rng, phot.ray(), hit) {
+                Some(ray) => *phot.ray_mut() = ray,
+                None => phot.kill(),
             }
         }
     }

--- a/src/sim/surface.rs
+++ b/src/sim/surface.rs
@@ -4,7 +4,7 @@ use crate::{
     geom::Hit,
     img::Colour,
     ord::{X, Y},
-    phys::{Crossing, Local, Photon},
+    phys::{Crossing, Local, Photon, Reflectance},
     sim::{Attribute, Output},
 };
 use rand::{rngs::ThreadRng, Rng};
@@ -97,7 +97,16 @@ pub fn surface(
         }
         Attribute::Reflector(ref reflectance) => {
             // TODO: Implement the reflection code for a ray hitting a surface. 
-            todo!()
+            print!("Reflect");
+            match reflectance {
+                Reflectance::Lambertian { albedo: _ } => {
+                    match reflectance.reflect(rng, phot.ray(), hit) {
+                        Some(ray) => { print!("Reflect: [{:?} -> {:?}]", phot.ray().dir(), ray.dir()); *phot.ray_mut() = ray; },
+                        None => phot.kill(),
+                    }
+                },
+                _ => todo!()
+            }
         }
     }
 }

--- a/src/sim/surface.rs
+++ b/src/sim/surface.rs
@@ -99,7 +99,7 @@ pub fn surface(
             // TODO: Implement the reflection code for a ray hitting a surface. 
 
             match reflectance {
-                Reflectance::Lambertian { albedo: _ } => {
+                Reflectance::Lambertian { albedo: _ } | Reflectance::Specular { albedo: _ } | Reflectance::Composite { diffuse_albedo: _,  specular_albedo: _, specular_diffuse_ratio: _}  => {
                     match reflectance.reflect(rng, phot.ray(), hit) {
                         Some(ray) => *phot.ray_mut() = ray,
                         None => phot.kill(),

--- a/src/sim/surface.rs
+++ b/src/sim/surface.rs
@@ -65,8 +65,8 @@ pub fn surface(
         }
         Attribute::Imager(id, width, ref orient) => {
             let projection = orient.pos() - phot.ray().pos();
-            let x = ((orient.right().dot(&projection.into()) / width) + 1.0) / 2.0;
-            let y = ((orient.up().dot(&projection.into()) / width) + 1.0) / 2.0;
+            let x = ((orient.right().dot_vec(&projection) / width) + 1.0) / 2.0;
+            let y = ((orient.up().dot_vec(&projection) / width) + 1.0) / 2.0;
 
             if (0.0..=1.0).contains(&x) && (0.0..=1.0).contains(&y) {
                 let res = data.imgs[id].pixels().raw_dim();
@@ -79,8 +79,8 @@ pub fn surface(
         }
         Attribute::Ccd(id, width, ref orient, ref binner) => {
             let projection = orient.pos() - phot.ray().pos();
-            let x = ((orient.right().dot(&projection.into()) / width) + 1.0) / 2.0;
-            let y = ((orient.up().dot(&projection.into()) / width) + 1.0) / 2.0;
+            let x = ((orient.right().dot_vec(&projection) / width) + 1.0) / 2.0;
+            let y = ((orient.up().dot_vec(&projection) / width) + 1.0) / 2.0;
 
             if (0.0..=1.0).contains(&x) && (0.0..=1.0).contains(&y) {
                 let res = data.ccds[id].raw_dim();
@@ -97,11 +97,11 @@ pub fn surface(
         }
         Attribute::Reflector(ref reflectance) => {
             // TODO: Implement the reflection code for a ray hitting a surface. 
-            print!("Reflect");
+
             match reflectance {
                 Reflectance::Lambertian { albedo: _ } => {
                     match reflectance.reflect(rng, phot.ray(), hit) {
-                        Some(ray) => { print!("Reflect: [{:?} -> {:?}]", phot.ray().dir(), ray.dir()); *phot.ray_mut() = ray; },
+                        Some(ray) => *phot.ray_mut() = ray,
                         None => phot.kill(),
                     }
                 },

--- a/src/tools/binner.rs
+++ b/src/tools/binner.rs
@@ -18,7 +18,7 @@ impl Binner {
     access!(range: Range);
     clone!(bins: usize);
 
-    /// Construct a new Range.
+    /// Construct a new Binner.
     #[inline]
     #[must_use]
     pub fn new(range: Range, bins: usize) -> Self {
@@ -59,3 +59,4 @@ impl Display for Binner {
         write!(fmt, "[{}] ({})", self.range, self.bins)
     }
 }
+

--- a/src/tools/binner.rs
+++ b/src/tools/binner.rs
@@ -59,4 +59,3 @@ impl Display for Binner {
         write!(fmt, "[{}] ({})", self.range, self.bins)
     }
 }
-


### PR DESCRIPTION
This PR includes the implementation of a `Reflectance` enum and the `Reflector` atrribute, which implements diffuse (Lambertian), specular and composite reflection models for geometries. Incuded in this PR are supporting code for reflectances, a slew of changes and fixes to underlying library code, and unit tests for each of the reflectance models. 