### PR TITLE
MPI functionality for the Photon struct

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ exclude = ["docs/", "input/", "output/"]
 
 [features]
 default = []
+mpi = ["dep:mpi", "dep:memoffset"]
 
 [dependencies]
 # ARCTK Dependencies
@@ -50,8 +51,10 @@ lidrs = "0.2.*"
 # Formats for the File I/O Library. 
 json5 = "0.4.*"
 netcdf = "0.8.1"
-mpi = "0.7.0"
-memoffset = "0.9.0"
+
+# Optional MPI dependencies
+mpi = { version = "0.7.0", optional = true }
+memoffset = { version = "0.9.0", optional = true }
 
 [dev-dependencies]
 tempfile = "3.2.*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,3 +70,8 @@ rustdoc-args = [ "--html-in-header", "./src/docs-header.html" ]
 
 [[bin]]
 name = "mcrt"
+
+[[bin]]
+name = "mpi_tests"
+path = "src/bin/tests/mpi_tests.rs"
+required-features = ["mpi"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,8 @@ lidrs = "0.2.*"
 # Formats for the File I/O Library. 
 json5 = "0.4.*"
 netcdf = "0.8.1"
+mpi = "0.7.0"
+memoffset = "0.9.0"
 
 [dev-dependencies]
 tempfile = "3.2.*"

--- a/src/phys/photon.rs
+++ b/src/phys/photon.rs
@@ -1,6 +1,11 @@
 //! Photon particle.
-
 use crate::{access, clone, geom::Ray, math::{Dir3, Point3}};
+use mpi::{
+    datatype::{UncommittedUserDatatype, UserDatatype},
+    traits::*,
+    Address,
+};
+use memoffset::{offset_of};
 
 /// Photon.
 #[derive(Clone)]
@@ -42,7 +47,6 @@ impl Photon {
         self.weight = 0.0;
     }
 }
-
 
 /// Photon reconstructed into raw data for MPI buffer.
 #[derive(Clone)]

--- a/src/phys/photon.rs
+++ b/src/phys/photon.rs
@@ -82,6 +82,27 @@ impl PhotonBuf {
         return Photon::new(ray, self.wavelength, self.power);
     }
 
-    
+}
 
+unsafe impl Equivalence for PhotonBuf {
+    type Out = UserDatatype;
+    fn equivalent_datatype() -> Self::Out {
+        UserDatatype::structured(
+            &[1, 1, 1, 1, 1],
+            &[
+                offset_of!(PhotonBuf, ray_pos) as Address,
+                offset_of!(PhotonBuf, ray_dir) as Address,
+                offset_of!(PhotonBuf, weight) as Address,
+                offset_of!(PhotonBuf, wavelength) as Address,
+                offset_of!(PhotonBuf, power) as Address,
+            ],
+            &[
+                UncommittedUserDatatype::contiguous(3, &f64::equivalent_datatype()).as_ref(),
+                UncommittedUserDatatype::contiguous(3, &f64::equivalent_datatype()).as_ref(),
+                f64::equivalent_datatype().into(),
+                f64::equivalent_datatype().into(),
+                f64::equivalent_datatype().into(),
+            ],
+        )
+    }
 }

--- a/src/phys/photon.rs
+++ b/src/phys/photon.rs
@@ -1,6 +1,6 @@
 //! Photon particle.
 
-use crate::{access, clone, geom::Ray};
+use crate::{access, clone, geom::Ray, math::{Dir3, Point3}};
 
 /// Photon.
 #[derive(Clone)]
@@ -41,4 +41,47 @@ impl Photon {
     pub fn kill(&mut self) {
         self.weight = 0.0;
     }
+}
+
+
+/// Photon reconstructed into raw data for MPI buffer.
+#[derive(Clone)]
+pub struct PhotonBuf {
+    /// Ray of travel broken down to component arrays
+    pub ray_pos: [f64; 3],
+    pub ray_dir: [f64; 3],
+    /// Statistical weight.
+    pub weight: f64,
+    /// Wavelength (m).
+    pub wavelength: f64,
+    /// Power (J/s).
+    pub power: f64,
+}
+
+impl PhotonBuf {
+
+    /// Construct a new instance.
+    #[inline]
+    #[must_use]
+    pub fn new(photon: Photon) -> Self {
+        Self {
+            ray_pos: [photon.ray().pos().x(), photon.ray().pos().y(), photon.ray().pos().z()],
+            ray_dir: [photon.ray().dir().x(), photon.ray().dir().y(), photon.ray().dir().z()],
+            weight: photon.weight(),
+            wavelength: photon.wavelength(),
+            power: photon.power(),
+        }
+    }
+
+    /// Convert photon buffer back to Photon struct
+    #[inline]
+    pub fn as_photon(self) -> Photon {
+        let ray = Ray::new(
+            Point3::new(self.ray_pos[0], self.ray_pos[1], self.ray_pos[2]),
+            Dir3::new(self.ray_dir[0], self.ray_dir[1], self.ray_dir[2]));
+        return Photon::new(ray, self.wavelength, self.power);
+    }
+
+    
+
 }


### PR DESCRIPTION
This PR enables the functionality to pass an instance of the ```Photon``` struct between processes using MPI. This functionality can be tested by enabling the ```mpi``` feature, as well as by running a test case with mpi:

```
cargo mpirun --features mpi --bin mpi_tests -n 2
```