### PR TITLE
Implementing a system dependency environment with Spack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ Cargo.lock
 
 #/target
 #Cargo.lock
+
+.spack/packages/aetherus-env/__pycache__/
+.spack-env

--- a/.spack/packages/aetherus-env/package.py
+++ b/.spack/packages/aetherus-env/package.py
@@ -1,9 +1,18 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
 import sys
 from spack import *
 
 class AetherusEnv(BundlePackage):
+    """A bundle package that sets the necessary environment variables needed
+    to build Aetherus within a Spack environment"""
 
-    version("test")
+    homepage = "https://github.com/aetherus-wg/Aetherus"
+
+    version("v0.2.0")
 
     depends_on("hdf5")
     depends_on("netcdf-c")

--- a/.spack/packages/aetherus-env/package.py
+++ b/.spack/packages/aetherus-env/package.py
@@ -1,0 +1,16 @@
+import sys
+from spack import *
+
+class AetherusEnv(BundlePackage):
+
+    version("test")
+
+    depends_on("hdf5")
+    depends_on("netcdf-c")
+
+    def setup_run_environment(self, env):
+        env.set("HDF5_DIR", f"{self.spec['hdf5'].prefix}")
+        if sys.platform == "darwin":
+            env.set("RUSTFLAGS", f"-C link-args=-L{self.spec['hdf5'].prefix}/lib, -ld_classic")
+        else:
+             env.set("RUSTFLAGS", f"-C link-args=-L{self.spec['hdf5'].prefix}/lib")

--- a/.spack/repo.yaml
+++ b/.spack/repo.yaml
@@ -1,0 +1,2 @@
+repo:
+  namespace: aetherus

--- a/README.md
+++ b/README.md
@@ -4,13 +4,23 @@ A Monte Carlo radiative transport code, supporting complex geometry - written in
 [![Aetherus crate](https://img.shields.io/crates/v/Aetherus.svg)](https://crates.io/crates/Aetherus)
 [![Aetherus documentation](https://docs.rs/Aetherus/badge.svg)](https://docs.rs/arctk)
 ![minimum rustc 1.47](https://img.shields.io/badge/rustc-1.47+-red.svg)
-[![Build Status](https://travis-ci.com/aetherus-wg/Aetherus.svg?branch=master)](https://travis-ci.com/aetherus-wg/Aetherus)
+[![Build Status](https://travis-ci.com/aetherus-wg/Aetherus.svg?branch=main)](https://travis-ci.com/aetherus-wg/Aetherus)
 
 
 ## Installation
 Install the rust compiler:
 
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
+System-level dependencies can be installed into a Spack environment. Spack can be installed with the following commands:
+
+    git clone --depth=100 --branch=releases/v0.21 https://github.com/spack/spack.git ~/spack
+    . ~/spack/share/spack/setup-env.sh
+
+The Spack environment can be installed with the following commands:
+
+    spack env activate -d .
+    spack install
 
 Check the source code:
 

--- a/spack.yaml
+++ b/spack.yaml
@@ -1,0 +1,14 @@
+# This is a Spack Environment file.
+#
+# It describes a set of packages to be installed, along with
+# configuration settings.
+spack:
+  # add package specs to the `specs` list
+  specs:
+  - netcdf-c@4.9.0 ^hdf5@1.12.2
+  - aetherus-env
+  view: true
+  concretizer:
+    unify: true
+  repos:
+  - ./.spack


### PR DESCRIPTION
This PR implements a system dependency environment using spack - to install this environment you simply need to run:
```shell
spacktivate .
spack install
```
from the top-level directory.
