### PR TITLE
Added hyperspectral output

### DIFF
--- a/src/bin/mcrt.rs
+++ b/src/bin/mcrt.rs
@@ -66,6 +66,8 @@ fn main() {
     report!(lights, "lights");
     let attrs = params
         .attrs
+        .link(base_output.reg.vol_reg.set())
+        .expect("Failed to link volume output to attributes. ")
         .link(base_output.reg.plane_reg.set())
         .expect("Failed to link plane output to attributes. ")
         .link(base_output.reg.phot_cols_reg.set())

--- a/src/io/output/output_volume.rs
+++ b/src/io/output/output_volume.rs
@@ -23,6 +23,7 @@ pub enum OutputParameter {
     Energy, 
     Absorption,
     Shift,
+    Hyperspectral,
 }
 
 impl std::fmt::Display for OutputParameter {
@@ -32,6 +33,7 @@ impl std::fmt::Display for OutputParameter {
             OutputParameter::Energy => "Energy",
             OutputParameter::Absorption => "Absorption",
             OutputParameter::Shift => "Shift",
+            OutputParameter::Hyperspectral => "Hyperspectral",
         };
         write!(f, "{}", param_str)
     }

--- a/src/sim/attribute/attribute.rs
+++ b/src/sim/attribute/attribute.rs
@@ -1,6 +1,6 @@
 //! Optical attributes.
 
-use crate::{fmt_report, geom::Orient, io::output::Rasteriser, phys::{Material, Reflectance}, tools::Binner};
+use crate::{fmt_report, geom::Orient, io::output::{Rasteriser, AxisAlignedPlane}, phys::{Material, Reflectance}, tools::Binner};
 use std::fmt::{Display, Error, Formatter};
 
 /// Surface attributes.
@@ -26,6 +26,8 @@ pub enum Attribute<'a> {
     AttributeChain(Vec<Attribute<'a>>),
     /// An output into the output plane object. This rasterises the photon packet into plane. 
     Rasterise(usize, Rasteriser),
+    /// Hyperspectral output - output into a volume output
+    Hyperspectral(usize, AxisAlignedPlane),
 }
 
 impl Display for Attribute<'_> {
@@ -77,6 +79,12 @@ impl Display for Attribute<'_> {
                 writeln!(fmt, "Rasterise: ...")?;
                 fmt_report!(fmt, id, "name");
                 fmt_report!(fmt, rast, "rasteriser");
+                Ok(())
+            }
+            Self::Hyperspectral(ref id, ref plane) => {
+                writeln!(fmt, "Hyperspectral: ...")?;
+                fmt_report!(fmt, id, "name");
+                fmt_report!(fmt, plane, "plane");
                 Ok(())
             }
         }

--- a/src/sim/attribute/attribute_linker.rs
+++ b/src/sim/attribute/attribute_linker.rs
@@ -9,7 +9,7 @@ use crate::{
     phys::Reflectance,
     sim::attribute::Attribute,
     tools::Binner,
-    io::output::Rasteriser,
+    io::output::{Rasteriser, AxisAlignedPlane},
 };
 use std::fmt::{Display, Formatter};
 
@@ -35,6 +35,8 @@ pub enum AttributeLinker {
     AttributeChain(Vec<AttributeLinker>),
     /// An output into the output plane object. This rasterises the photon packet into plane. 
     Rasterise(usize, Rasteriser),
+    /// Hyperspectral output - output into a volume output
+    Hyperspectral(usize, AxisAlignedPlane),
 }
 
 impl<'a> Link<'a, Material> for AttributeLinker {
@@ -51,7 +53,8 @@ impl<'a> Link<'a, Material> for AttributeLinker {
             | Self::Reflector(..)
             | Self::PhotonCollector(..) 
             | Self::AttributeChain(..) 
-            | Self::Rasterise(..) => {
+            | Self::Rasterise(..)
+            | Self::Hyperspectral(..) => {
                 vec![]
             }
         }
@@ -82,6 +85,7 @@ impl<'a> Link<'a, Material> for AttributeLinker {
                 Self::Inst::AttributeChain(linked_attrs?)
             }
             Self::Rasterise(id, rast) => Self::Inst::Rasterise(id, rast),
+            Self::Hyperspectral(id, plane) => Self::Inst::Hyperspectral(id, plane),
         })
     }
 }
@@ -135,6 +139,12 @@ impl Display for AttributeLinker {
                 writeln!(fmt, "Rasterise: ...")?;
                 fmt_report!(fmt, id, "name");
                 fmt_report!(fmt, rast, "rasteriser");
+                Ok(())
+            }
+            Self::Hyperspectral(ref id, ref plane) => {
+                writeln!(fmt, "Hyperspectral: ...")?;
+                fmt_report!(fmt, id, "name");
+                fmt_report!(fmt, plane, "plane");
                 Ok(())
             }
         }

--- a/src/sim/attribute/attribute_linker_chain_proxy.rs
+++ b/src/sim/attribute/attribute_linker_chain_proxy.rs
@@ -1,7 +1,7 @@
 use arctk_attr::file;
-use crate::{ord::Set, sim::AttributeLinkerLinkerLinkerLinkerLinkerLinker};
+use crate::{ord::Set, sim::AttributeLinkerLinkerLinkerLinkerLinkerLinkerLinker};
 
-type LinkerChainStart = AttributeLinkerLinkerLinkerLinkerLinkerLinker;
+pub type LinkerChainStart = AttributeLinkerLinkerLinkerLinkerLinkerLinkerLinker;
 
 /// This is the jumping on point for the attribute chain. 
 /// This enum serves a dual purpose. It simultaneously acts as as a convenient

--- a/src/sim/attribute/attribute_linker_linker.rs
+++ b/src/sim/attribute/attribute_linker_linker.rs
@@ -8,7 +8,7 @@ use crate::{
     phys::Reflectance,
     sim::attribute::AttributeLinker,
     tools::{Binner, Range},
-    io::output::Rasteriser,
+    io::output::{Rasteriser, AxisAlignedPlane},
 };
 use std::fmt::{Display, Formatter};
 
@@ -35,6 +35,8 @@ pub enum AttributeLinkerLinker {
     AttributeChain(Vec<AttributeLinkerLinker>),
     /// An output into the output plane object. This rasterises the photon packet into plane. 
     Rasterise(usize, Rasteriser),
+    /// Hyperspectral output - output into a volume output
+    Hyperspectral(usize, AxisAlignedPlane),
 }
 
 impl<'a> Link<'a, usize> for AttributeLinkerLinker {
@@ -66,6 +68,7 @@ impl<'a> Link<'a, usize> for AttributeLinkerLinker {
                 Self::Inst::AttributeChain(linked_attrs?)
             }
             Self::Rasterise(id, rast) => Self::Inst::Rasterise(id, rast),
+            Self::Hyperspectral(id, plane) => Self::Inst::Hyperspectral(id, plane),
         })
     }
 }
@@ -125,6 +128,12 @@ impl Display for AttributeLinkerLinker {
                 writeln!(fmt, "Rasterise: ...")?;
                 fmt_report!(fmt, id, "name");
                 fmt_report!(fmt, rast, "rasteriser");
+                Ok(())
+            }
+            Self::Hyperspectral(ref id, ref plane) => {
+                writeln!(fmt, "Hyperspectral: ...")?;
+                fmt_report!(fmt, id, "name");
+                fmt_report!(fmt, plane, "plane");
                 Ok(())
             }
         }

--- a/src/sim/attribute/attribute_linker_linker_linker.rs
+++ b/src/sim/attribute/attribute_linker_linker_linker.rs
@@ -9,7 +9,7 @@ use crate::{
     phys::Reflectance,
     sim::attribute::AttributeLinkerLinker,
     tools::{Binner, Range},
-    io::output::Rasteriser,
+    io::output::{Rasteriser, AxisAlignedPlane},
 };
 use std::fmt::{Display, Formatter};
 
@@ -36,6 +36,9 @@ pub enum AttributeLinkerLinkerLinker {
     AttributeChain(Vec<AttributeLinkerLinkerLinker>),
     /// An output into the output plane object. This rasterises the photon packet into plane. 
     Rasterise(usize, Rasteriser),
+    /// Hyperspectral output - output into a volume output
+    Hyperspectral(usize, AxisAlignedPlane),
+    
 }
 
 impl<'a> Link<'a, usize> for AttributeLinkerLinkerLinker {
@@ -71,6 +74,7 @@ impl<'a> Link<'a, usize> for AttributeLinkerLinkerLinker {
                 Self::Inst::AttributeChain(linked_attrs?)
             }
             Self::Rasterise(id, rast) => Self::Inst::Rasterise(id, rast),
+            Self::Hyperspectral(id, plane) => Self::Inst::Hyperspectral(id, plane),
         })
     }
 }
@@ -132,6 +136,12 @@ impl Display for AttributeLinkerLinkerLinker {
                 writeln!(fmt, "Rasterise: ...")?;
                 fmt_report!(fmt, id, "name");
                 fmt_report!(fmt, rast, "rasteriser");
+                Ok(())
+            }
+            Self::Hyperspectral(ref id, ref plane) => {
+                writeln!(fmt, "Hyperspectral: ...")?;
+                fmt_report!(fmt, id, "name");
+                fmt_report!(fmt, plane, "plane");
                 Ok(())
             }
         }

--- a/src/sim/attribute/attribute_linker_linker_linker_linker_linker.rs
+++ b/src/sim/attribute/attribute_linker_linker_linker_linker_linker.rs
@@ -8,9 +8,8 @@ use crate::{
     phys::{ReflectanceBuilder, ReflectanceBuilderShim},
     sim::attribute::AttributeLinkerLinkerLinkerLinker,
     tools::{Binner, Range},
-    io::output::Rasteriser,
+    io::output::{Rasteriser, AxisAlignedPlane},
 };
-use arctk_attr::file;
 use std::fmt::{Display, Formatter};
 
 /// Surface attribute setup.
@@ -37,6 +36,8 @@ pub enum AttributeLinkerLinkerLinkerLinkerLinker {
     AttributeChain(Vec<AttributeLinkerLinkerLinkerLinkerLinker>),
     /// An output into the output plane object. This rasterises the photon packet into plane. 
     Rasterise(usize, Rasteriser),
+    /// Hyperspectral output - output into a volume output
+    Hyperspectral(usize, AxisAlignedPlane),
 }
 
 impl<'a> Link<'a, usize> for AttributeLinkerLinkerLinkerLinkerLinker {
@@ -79,6 +80,7 @@ impl<'a> Link<'a, usize> for AttributeLinkerLinkerLinkerLinkerLinker {
                 Self::Inst::AttributeChain(linked_attrs?)
             }
             Self::Rasterise(id, rast) => Self::Inst::Rasterise(id, rast),
+            Self::Hyperspectral(id, plane) => Self::Inst::Hyperspectral(id, plane),
         })
     }
 }
@@ -169,6 +171,12 @@ impl Display for AttributeLinkerLinkerLinkerLinkerLinker {
                 writeln!(fmt, "Rasterise: ...")?;
                 fmt_report!(fmt, id, "name");
                 fmt_report!(fmt, rast, "rasteriser");
+                Ok(())
+            },
+            Self::Hyperspectral(ref id, ref plane) => {
+                writeln!(fmt, "Hyperspectral: ...")?;
+                fmt_report!(fmt, id, "name");
+                fmt_report!(fmt, plane, "plane");
                 Ok(())
             }
         }

--- a/src/sim/attribute/attribute_linker_linker_linker_linker_linker_linker.rs
+++ b/src/sim/attribute/attribute_linker_linker_linker_linker_linker_linker.rs
@@ -1,7 +1,7 @@
 //! Attribute first-stage imager linker.
 
 use crate::{
-    err::Error, fmt_report, io::output::RasteriseBuilder, math::{trans3_builder, Point3, ProbabilityBuilder, Vec3}, ord::{cartesian::{X, Y}, Link, Name, Set}, phys::{synphot::TransmissionBuilder, ReflectanceBuilderShim}, sim::attribute::AttributeLinkerLinkerLinkerLinkerLinker, tools::{Binner, Range}
+    err::Error, fmt_report, io::output::{RasteriseBuilder, AxisAlignedPlane}, math::{Point3, Vec3}, ord::{cartesian::{X, Y}, Link, Name, Set}, phys::ReflectanceBuilderShim, sim::attribute::AttributeLinkerLinkerLinkerLinkerLinker, tools::{Binner, Range}
 };
 use arctk_attr::file;
 use std::fmt::{Display, Formatter};
@@ -30,7 +30,9 @@ pub enum AttributeLinkerLinkerLinkerLinkerLinkerLinker {
     /// A chain of attributes where are executed in order. 
     AttributeChain(Vec<AttributeLinkerLinkerLinkerLinkerLinkerLinker>),
     /// An output into the output plane object. This rasterises the photon packet into plane. 
-    Rasterise(Name, RasteriseBuilder)
+    Rasterise(Name, RasteriseBuilder),
+    /// Hyperspectral output - output into a volume output
+    Hyperspectral(usize, AxisAlignedPlane),
 }
 
 impl<'a> Link<'a, usize> for AttributeLinkerLinkerLinkerLinkerLinkerLinker {
@@ -72,7 +74,10 @@ impl<'a> Link<'a, usize> for AttributeLinkerLinkerLinkerLinkerLinkerLinker {
                 let linked_id = *reg.get(&id)
                     .unwrap_or_else(|| panic!("Failed to link attribute-rasterise key: {}", id));
                 Self::Inst::Rasterise(linked_id, rast_build.build())
-            }
+            },
+            Self::Hyperspectral(id, plane) => {
+                Self::Inst::Hyperspectral(id, plane)
+            },
         })
     }
 }
@@ -163,6 +168,12 @@ impl Display for AttributeLinkerLinkerLinkerLinkerLinkerLinker {
                 writeln!(fmt, "Rasterise: ...")?;
                 fmt_report!(fmt, id, "name");
                 fmt_report!(fmt, rast_builder, "rasteriser");
+                Ok(())
+            }
+            Self::Hyperspectral(ref id, ref plane) => {
+                writeln!(fmt, "Hyperspectral: ...")?;
+                fmt_report!(fmt, id, "id");
+                fmt_report!(fmt, plane, "plane");
                 Ok(())
             }
         }

--- a/src/sim/attribute/mod.rs
+++ b/src/sim/attribute/mod.rs
@@ -6,6 +6,7 @@ pub mod attribute_linker_linker_linker;
 pub mod attribute_linker_linker_linker_linker;
 pub mod attribute_linker_linker_linker_linker_linker;
 pub mod attribute_linker_linker_linker_linker_linker_linker;
+pub mod attribute_linker_linker_linker_linker_linker_linker_linker;
 
 pub use self::{
     attribute::*, attribute_linker_chain_proxy::*,
@@ -13,4 +14,5 @@ pub use self::{
     attribute_linker_linker_linker::*, attribute_linker_linker_linker_linker::*,
     attribute_linker_linker_linker_linker_linker::*,
     attribute_linker_linker_linker_linker_linker_linker::*,
+    attribute_linker_linker_linker_linker_linker_linker_linker::*,
 };

--- a/src/sim/param/parameters.rs
+++ b/src/sim/param/parameters.rs
@@ -1,7 +1,7 @@
 //! Runtime parameters.
 
 use crate::{
-    fmt_report, geom::{Boundary, SurfaceLinker, TreeSettings}, io::output::OutputConfig, ord::Set, phys::{LightLinker, Material}, sim::{AttributeLinkerLinkerLinkerLinkerLinkerLinker, Engine, Settings}
+    fmt_report, geom::{Boundary, SurfaceLinker, TreeSettings}, io::output::OutputConfig, ord::Set, phys::{LightLinker, Material}, sim::{LinkerChainStart, Engine, Settings}
 };
 use std::fmt::{Display, Error, Formatter};
 
@@ -16,7 +16,7 @@ pub struct Parameters {
     /// Surfaces.
     pub surfs: Set<SurfaceLinker>,
     /// Attributes.
-    pub attrs: Set<AttributeLinkerLinkerLinkerLinkerLinkerLinker>,
+    pub attrs: Set<LinkerChainStart>,
     /// Materials.
     pub mats: Set<Material>,
     /// Main light.
@@ -37,7 +37,7 @@ impl Parameters {
         boundary: Boundary,
         tree: TreeSettings,
         surfs: Set<SurfaceLinker>,
-        attrs: Set<AttributeLinkerLinkerLinkerLinkerLinkerLinker>,
+        attrs: Set<LinkerChainStart>,
         mats: Set<Material>,
         lights: Set<LightLinker>,
         engine: Engine,

--- a/src/sim/param/parameters_builder.rs
+++ b/src/sim/param/parameters_builder.rs
@@ -1,7 +1,7 @@
 //! Buildable parameters.
 
 use crate::{
-    fmt_report, geom::{BoundaryBuilder, SurfaceLinker, TreeSettings}, io::output::OutputConfig, ord::{Build, Set}, phys::{LightLinkerBuilder, MaterialBuilder}, sim::{AttributeLinkerLinkerLinkerLinkerLinkerLinker, EngineBuilder, Parameters, Settings}
+    fmt_report, geom::{BoundaryBuilder, SurfaceLinker, TreeSettings}, io::output::OutputConfig, ord::{Build, Set}, phys::{LightLinkerBuilder, MaterialBuilder}, sim::{LinkerChainStart, EngineBuilder, Parameters, Settings}
 };
 use std::fmt::{Display, Error, Formatter};
 
@@ -16,7 +16,7 @@ pub struct ParametersBuilder {
     /// Surfaces.
     surfs: Set<SurfaceLinker>,
     /// Attributes.
-    attrs: Set<AttributeLinkerLinkerLinkerLinkerLinkerLinker>,
+    attrs: Set<LinkerChainStart>,
     /// Materials.
     mats: Set<MaterialBuilder>,
     /// Main light.
@@ -37,7 +37,7 @@ impl ParametersBuilder {
         boundary: BoundaryBuilder,
         tree: TreeSettings,
         surfs: Set<SurfaceLinker>,
-        attrs: Set<AttributeLinkerLinkerLinkerLinkerLinkerLinker>,
+        attrs: Set<LinkerChainStart>,
         mats: Set<MaterialBuilder>,
         lights: Set<LightLinkerBuilder>,
         engine: EngineBuilder,

--- a/src/sim/peel_off.rs
+++ b/src/sim/peel_off.rs
@@ -75,7 +75,8 @@ pub fn peel_off(input: &Input, mut phot: Photon, env: &Local, pos: Point3) -> Op
                 | Attribute::Reflector(..)
                 | Attribute::PhotonCollector(..) 
                 | Attribute::AttributeChain(..) 
-                | Attribute::Rasterise(..) => return None,
+                | Attribute::Rasterise(..)
+                | Attribute::Hyperspectral(..) => return None,
             }
         } else {
             prob *= (-tar_dist * inter_coeff).exp();

--- a/src/sim/surface.rs
+++ b/src/sim/surface.rs
@@ -1,12 +1,7 @@
 //! Photon scattering function.
 
 use crate::{
-    geom::Hit,
-    img::Colour,
-    ord::cartesian::{X, Y},
-    phys::{Crossing, Local, Photon},
-    sim::Attribute,
-    io::output::Output,
+    geom::Hit, img::Colour, io::output::{Output, OutputParameter}, math::Point3, ord::cartesian::{X, Y}, phys::{Crossing, Local, Photon}, sim::Attribute
 };
 use rand::{rngs::ThreadRng, Rng};
 
@@ -111,6 +106,16 @@ pub fn surface(
         },
         Attribute::Rasterise(id, ref rasteriser) => {
             rasteriser.rasterise(rng, phot, &mut data.plane[id]);
+        },
+        Attribute::Hyperspectral(ref id, ref plane) => {
+            assert_eq!(*data.vol[*id].param(), OutputParameter::Hyperspectral, "Hyperspectral output target not set to 'hyperspectral' param. ");
+
+            let projected_xy = plane.project_onto_plane(phot.ray().pos());
+            let hp_loc = Point3::new(projected_xy.0, projected_xy.1, phot.wavelength());
+            match data.vol[*id].gen_index(&hp_loc) {
+                Some(index) => data.vol[*id].data_mut()[index] += phot.power() * phot.weight(),
+                None => {},
+            }
         }
     }
 }


### PR DESCRIPTION
Added ability to output an XY plane of spectra for each pixel into a volume output. This PR includes:
- Necessary addition to `Attribute` and linking chain to add `Hyperspectral` variant. 
- On the last point, I have added a layer to the linker chain to allow linking to volume outputs. 
- Implementation into surface hit. 
- Addition of output volume parameter variant. 
- Integration into MCRT binary. 