### PR TITLE
Added photon packet counter to `Rasterise` attrib.

### DIFF
--- a/src/io/output/rasterise.rs
+++ b/src/io/output/rasterise.rs
@@ -6,8 +6,12 @@ use std::fmt::{Display, Formatter};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Rasteriser {
+    /// Rasterises the illuminance of the photons fed to the rasteriser using 
+    /// a provided transmission function. 
     Illuminance(Transmission),
-    CorrelatedColourTemperature,
+    /// Counts the number of photon packets that trigger the rasteriser by summing
+    /// their weights. 
+    PhotonCount,
 }
 
 impl Rasteriser {
@@ -25,8 +29,12 @@ impl Rasteriser {
                     } 
                 };
             }
-            Self::CorrelatedColourTemperature => {
-                todo!()
+            Self::PhotonCount => {
+                let xy = plane.project(phot.ray().pos());
+                match plane.at_mut(xy.0, xy.1) {
+                    Some(pix) => *pix += phot.weight(),
+                    None => panic!("Photon count rasterisation outside raster"),
+                }   
             }
         }
     }
@@ -40,8 +48,8 @@ impl Display for Rasteriser {
                 writeln!(fmt, "Illuminance: ")?;
                 fmt_report!(fmt, trans, "transmission function")
             }
-            Self::CorrelatedColourTemperature => {
-                writeln!(fmt, "CorrelatedColourTemperature: ")?;
+            Self::PhotonCount => {
+                writeln!(fmt, "PhotonCount: ...")?;
             }
         }
         Ok(())

--- a/src/io/output/rasterise_builder.rs
+++ b/src/io/output/rasterise_builder.rs
@@ -10,14 +10,14 @@ use super::Rasteriser;
 #[derive(Clone)]
 pub enum RasteriseBuilder {
     Illuminance(TransmissionBuilder),
-    CorrelatedColourTemperature,
+    PhotonCount,
 }
 
 impl RasteriseBuilder {
     pub fn build(&self) -> Rasteriser {
         match self {
             Self::Illuminance(ref tb) => Rasteriser::Illuminance(tb.build()),
-            Self::CorrelatedColourTemperature => todo!(),
+            Self::PhotonCount => Rasteriser::PhotonCount,
         }
     }
 }
@@ -29,9 +29,8 @@ impl Display for RasteriseBuilder {
                 writeln!(fmt, "Illuminance: ...")?;
                 fmt_report!(fmt, tb, "transmission")
             },
-            Self::CorrelatedColourTemperature => {
-                writeln!(fmt, "Correlated Colour Temperature: ...")?;
-
+            Self::PhotonCount => {
+                writeln!(fmt, "Count: ...")?;
             }
         }
         Ok(())


### PR DESCRIPTION
- Added variant to `Rasterise` enum.
- Added variant to `RasteriseBuilder` enum, to allow deserialisation and building from JSON5.
- Removed unneeded `CorrelatedColourTemperature` variant to enum, as this is now implemented via hyperspectral output + post-processing.