### PR TITLE
Invdir speedup

### DIFF
--- a/src/geom/cast/camera.rs
+++ b/src/geom/cast/camera.rs
@@ -89,9 +89,10 @@ impl Camera {
         phi -= self.half_delta_theta * (self.res[Y] * self.ss_power) as f64;
 
         let mut ray = self.orient.forward_ray();
-        *ray.dir_mut() = Rot3::from_axis_angle(&Vec3::from(self.orient.down()), theta)
+        let new_dir = Rot3::from_axis_angle(&Vec3::from(self.orient.down()), theta)
             * Rot3::from_axis_angle(&Vec3::from(*self.orient.right()), phi)
             * ray.dir();
+        ray.update_dir(new_dir);
 
         ray
     }

--- a/src/geom/rt/ray.rs
+++ b/src/geom/rt/ray.rs
@@ -11,7 +11,7 @@ use nalgebra::Vector3;
 ///
 /// This is the type at the core of our ray tracing / hit scan implementation.
 /// This is also the type at the core of our photon implementation.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 pub struct Ray {
     /// Ray origin.
     pos: Point3,
@@ -19,6 +19,12 @@ pub struct Ray {
     dir: Dir3,
     /// Inverse ray direction, to compute division using multiplication
     invdir: Vector3<Real>,
+}
+
+impl PartialEq for Ray {
+    fn eq(&self, other: &Self) -> bool {
+        self.pos == other.pos && self.dir == other.dir
+    }
 }
 
 impl Ray {

--- a/src/geom/rt/ray.rs
+++ b/src/geom/rt/ray.rs
@@ -2,8 +2,10 @@
 
 use crate::{
     access,
+    core::Real,
     math::{Dir3, Point3, Rot3, Vec3},
 };
+use nalgebra::Vector3;
 
 /// Ray structure.
 ///
@@ -15,18 +17,22 @@ pub struct Ray {
     pos: Point3,
     /// Ray direction.
     dir: Dir3,
+    /// Inverse ray direction, to compute division using multiplication
+    invdir: Vector3<Real>,
 }
 
 impl Ray {
     access!(pos, pos_mut: Point3);
-    access!(dir, dir_mut: Dir3);
+    access!(dir: Dir3);
+    access!(invdir: Vector3<Real>);
 
     /// Construct a new instance.
     #[inline]
     #[must_use]
     pub fn new(pos: Point3, mut dir: Dir3) -> Self {
         let _ = dir.renormalize();
-        Self { pos, dir }
+        let invdir = Vector3::new(1.0_f64 / dir.x(), 1.0_f64 / dir.y(), 1.0_f64 / dir.z());
+        Self { pos, dir, invdir }
     }
 
     /// Destruct self into components.
@@ -34,6 +40,12 @@ impl Ray {
     #[must_use]
     pub const fn destruct(self) -> (Point3, Dir3) {
         (self.pos, self.dir)
+    }
+
+    pub fn update_dir(&mut self, mut dir: Dir3) {
+        let _ = dir.renormalize();
+        self.dir = dir;
+        self.invdir = Vector3::new(1.0 / dir.x(), 1.0 / dir.y(), 1.0 / dir.z());
     }
 
     /// Move along the direction of travel a given distance.
@@ -57,8 +69,7 @@ impl Ray {
         let pitch_rot = Rot3::from_axis_angle(&Vec3::from(pitch_axis), pitch);
         let roll_rot = Rot3::from_axis_angle(&Vec3::from(self.dir), roll);
 
-        self.dir = roll_rot * pitch_rot * self.dir;
-        let _ = self.dir.renormalize();
+        self.update_dir(roll_rot * pitch_rot * self.dir);
     }
 }
 

--- a/src/geom/shape/cube.rs
+++ b/src/geom/shape/cube.rs
@@ -170,8 +170,8 @@ impl Cube {
             }
             (f64::NEG_INFINITY, f64::INFINITY)
         } else {
-            let t1 = (self.mins.x() - ray.pos().x()) / ray.dir().x();
-            let t2 = (self.maxs.x() - ray.pos().x()) / ray.dir().x();
+            let t1 = (self.mins.x() - ray.pos().x()) * ray.invdir().x;
+            let t2 = (self.maxs.x() - ray.pos().x()) * ray.invdir().x;
             (t1.min(t2), t1.max(t2))
         };
 
@@ -182,8 +182,8 @@ impl Cube {
             }
             (f64::NEG_INFINITY, f64::INFINITY)
         } else {
-            let t1 = (self.mins.y() - ray.pos().y()) / ray.dir().y();
-            let t2 = (self.maxs.y() - ray.pos().y()) / ray.dir().y();
+            let t1 = (self.mins.y() - ray.pos().y()) * ray.invdir().y;
+            let t2 = (self.maxs.y() - ray.pos().y()) * ray.invdir().y;
             (t1.min(t2), t1.max(t2))
         };
 
@@ -200,8 +200,8 @@ impl Cube {
             }
             (f64::NEG_INFINITY, f64::INFINITY)
         } else {
-            let t1 = (self.mins.z() - ray.pos().z()) / ray.dir().z();
-            let t2 = (self.maxs.z() - ray.pos().z()) / ray.dir().z();
+            let t1 = (self.mins.z() - ray.pos().z()) * ray.invdir().z;
+            let t2 = (self.maxs.z() - ray.pos().z()) * ray.invdir().z;
             (t1.min(t2), t1.max(t2))
         };
 

--- a/src/geom/shape/cube.rs
+++ b/src/geom/shape/cube.rs
@@ -10,7 +10,6 @@ use crate::{
 use arctk_attr::file;
 use rand::Rng;
 use std::{
-    cmp::Ordering,
     fmt::{Display, Formatter},
 };
 
@@ -163,53 +162,56 @@ impl Cube {
     #[inline]
     #[must_use]
     fn intersections(&self, ray: &Ray) -> (f64, f64) {
-        // TODO: Precompute 1/ray.dir() as it's used at every Voxel transition and f64 div
-        // takes much longer thatn f64 mul
-        let t_0: Vec<_> = self
-            .mins
-            .iter()
-            .zip(ray.pos().iter().zip(ray.dir().iter()))
-            .map(|(m, (p, d))| (m - p) / d)
-            .filter(|x| x.is_finite())
-            .map(|x| if x== -0.0 {0.0} else {x}) // Handle negative zero case
-            .collect();
+        // X slab
+        let (mut tmin, mut tmax) = if ray.dir().x() == 0.0 {
+            // Ray parallel to x planes
+            if ray.pos().x() < self.mins.x() || ray.pos().x() > self.maxs.x() {
+                return (f64::INFINITY, f64::NEG_INFINITY);
+            }
+            (f64::NEG_INFINITY, f64::INFINITY)
+        } else {
+            let t1 = (self.mins.x() - ray.pos().x()) / ray.dir().x();
+            let t2 = (self.maxs.x() - ray.pos().x()) / ray.dir().x();
+            (t1.min(t2), t1.max(t2))
+        };
 
-        let t_1: Vec<_> = self
-            .maxs
-            .iter()
-            .zip(ray.pos().iter().zip(ray.dir().iter()))
-            .map(|(m, (p, d))| (m - p) / d)
-            .filter(|x| x.is_finite())
-            .map(|x| if x== -0.0 {0.0} else {x}) // Handle negative zero case
-            .collect();
+        // Y slab
+        let (tymin, tymax) = if ray.dir().y() == 0.0 {
+            if ray.pos().y() < self.mins.y() || ray.pos().y() > self.maxs.y() {
+                return (f64::INFINITY, f64::NEG_INFINITY);
+            }
+            (f64::NEG_INFINITY, f64::INFINITY)
+        } else {
+            let t1 = (self.mins.y() - ray.pos().y()) / ray.dir().y();
+            let t2 = (self.maxs.y() - ray.pos().y()) / ray.dir().y();
+            (t1.min(t2), t1.max(t2))
+        };
 
-        let t_min = t_0
-            .iter()
-            .zip(t_1.iter())
-            .map(|(a, b)| a.min(*b))
-            .max_by(|a, b| {
-                if a < b {
-                    Ordering::Less
-                } else {
-                    Ordering::Greater
-                }
-            })
-            .unwrap();
+        if tmin > tymax || tymin > tmax {
+            return (f64::INFINITY, f64::NEG_INFINITY);
+        }
+        tmin = tmin.max(tymin);
+        tmax = tmax.min(tymax);
 
-        let t_max = t_0
-            .iter()
-            .zip(t_1.iter())
-            .map(|(a, b)| a.max(*b))
-            .min_by(|a, b| {
-                if a < b {
-                    Ordering::Less
-                } else {
-                    Ordering::Greater
-                }
-            })
-            .unwrap();
+        // Z slab
+        let (tzmin, tzmax) = if ray.dir().z() == 0.0 {
+            if ray.pos().z() < self.mins.z() || ray.pos().z() > self.maxs.z() {
+                return (f64::INFINITY, f64::NEG_INFINITY);
+            }
+            (f64::NEG_INFINITY, f64::INFINITY)
+        } else {
+            let t1 = (self.mins.z() - ray.pos().z()) / ray.dir().z();
+            let t2 = (self.maxs.z() - ray.pos().z()) / ray.dir().z();
+            (t1.min(t2), t1.max(t2))
+        };
 
-        (t_min, t_max)
+        if tmin > tzmax || tzmin > tmax {
+            return (f64::INFINITY, f64::NEG_INFINITY);
+        }
+        tmin = tmin.max(tzmin);
+        tmax = tmax.min(tzmax);
+
+        (tmin, tmax)
     }
 
     /// Generate a random position within the cube's volume.

--- a/src/sim/peel_off.rs
+++ b/src/sim/peel_off.rs
@@ -27,7 +27,7 @@ pub fn peel_off(input: &Input, mut phot: Photon, env: &Local, pos: Point3) -> Op
         return None;
     }
 
-    *phot.ray_mut().dir_mut() = dir;
+    phot.ray_mut().update_dir(dir);
 
     let loop_limit = input.sett.loop_limit();
     let bump_dist = input.sett.bump_dist();

--- a/src/sim/surface.rs
+++ b/src/sim/surface.rs
@@ -57,18 +57,20 @@ pub fn surface(
             let r = rng.gen::<f64>();
             if r <= crossing.ref_prob() {
                 // Reflect.
-                *phot.ray_mut().dir_mut() = *crossing.ref_dir();
+                phot.ray_mut().update_dir(*crossing.ref_dir());
                 EventId { event_type: EventType::MCRT(mcrt_event!(Interface, Reflection)), src_id: hit.tag().src_id }
             } else {
                 // Refract.
-                *phot.ray_mut().dir_mut() = crossing.trans_dir().expect("Invalid refraction.");
+                let new_dir = crossing.trans_dir().expect("Invalid refraction.");
+                phot.ray_mut().update_dir(new_dir);
                 *env = next_env;
                 EventId { event_type: EventType::MCRT(mcrt_event!(Interface, Refraction)), src_id: env.mat_id() }
             }
         }
         Attribute::Mirror(abs) => {
             *phot.weight_mut() *= abs;
-            *phot.ray_mut().dir_mut() = Crossing::calc_ref_dir(phot.ray().dir(), hit.side().norm());
+            let new_dir = Crossing::calc_ref_dir(phot.ray().dir(), hit.side().norm());
+            phot.ray_mut().update_dir(new_dir);
             EventId { event_type: EventType::MCRT(mcrt_event!(Reflector, Specular)), src_id: hit.tag().src_id }
         }
         Attribute::Spectrometer(id) => {

--- a/src/sim/surface.rs
+++ b/src/sim/surface.rs
@@ -127,7 +127,9 @@ pub fn surface(
                 // sorted out properly.
                 let mut future_phot = phot.clone();
                 let event_id = EventId { event_type: EventType::Detection, src_id: hit.tag().src_id };
-                *future_phot.uid_mut() = Uid::from_event(seq_id.unwrap(), &event_id);
+                if let Some(seq_id) = seq_id {
+                    *future_phot.uid_mut() = Uid::from_event(seq_id, &event_id);
+                }
                 data.phot_cols[id].collect_photon(&mut future_phot);
                 if future_phot.weight() <= 0.0 {
                     phot.kill();


### PR DESCRIPTION
Compute `1/dir` only once, such that we only use the FPU DIV only once per photon direction. Then, MUL is used for finding out intersections, saving around 100 clk cycles per intersection.