### PR TITLE
Ledger tree: Photon packets hold node to history instead of UID

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ thiserror = "2.0.17"
 log = "0.4.29"
 rand_distr = "0.6.0"
 env_logger = "0.11.9"
-aetherus-events = { git = "https://github.com/aetherus-wg/aetherus-events", version = "^0.3.5" }
+events-ledger = "^0.3.6"
 
 [dev-dependencies]
 tempfile = "3.2.*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,12 +77,6 @@ criterion = { version = "0.8.2", features = ["html_reports", "rayon"] }
 integrate = "0.3.1"
 plotters = "0.3.7"
 
-[build]
-rustdocflags = [ "--html-in-header", "./src/docs-header.html" ]
-
-[package.metadata.docs.rs]
-rustdoc-args = [ "--html-in-header", "./src/docs-header.html" ]
-
 [lib]
 
 [[bin]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ thiserror = "2.0.17"
 log = "0.4.29"
 rand_distr = "0.6.0"
 env_logger = "0.11.9"
-aetherus-events = { git = "https://github.com/aetherus-wg/aetherus-events", tag ="0.2.3", version = "^0.2.3" }
+aetherus-events = { git = "https://github.com/aetherus-wg/aetherus-events", version = "^0.3.5" }
 
 [dev-dependencies]
 tempfile = "3.2.*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aetherus"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Freddy Wordingham <f.wordingham@exeter.ac.uk>", "Sam Morrell <s.a.f.morrell@exeter.ac.uk>", "Cristian Bourceanu <v.c.bourceanu@smd.ed.ac.uk>"]
 edition = "2021"
 description = "Physics simulation library and binaries"

--- a/benches/diffusion.rs
+++ b/benches/diffusion.rs
@@ -11,7 +11,7 @@ use aetherus::{
     sim::{Attribute, Parameters, ParametersBuilderLoader}
 };
 
-use aetherus_events::{SrcId, ledger::Ledger};
+use aetherus_events::prelude::*;
 use anyhow::Context;
 use criterion::{criterion_group, criterion_main, Criterion};
 use std::hint::black_box;
@@ -32,20 +32,20 @@ fn criterion_config(c: &mut Criterion) {
     });
 
     let params = load_parameters(&input_dir, &params_path);
-    let (ledger, mats) = build_ledger(&params);
+    let (mut ledger, mats) = build_ledger(&params);
     let _lights = build_lights(&params, &mats);
     let base_output = params.output.clone().build(()).unwrap();
 
     // Build objects
     c.bench_function("build_objects", |b| {
         b.iter(|| {
-            let (ledger, mats) = build_ledger(&params);
-            let (objs, attrs) = build_objects(black_box(&params), black_box(&base_output), &ledger, &mats).unwrap();
+            let (mut ledger, mats) = build_ledger(&params);
+            let (objs, attrs) = build_objects(black_box(&params), black_box(&base_output), &mut ledger, &mats).unwrap();
             black_box((objs, attrs))
         });
     });
 
-    let (objs, _attrs) = build_objects(&params, &base_output, &ledger, &mats).unwrap();
+    let (objs, _attrs) = build_objects(&params, &base_output, &mut ledger, &mats).unwrap();
 
     //// Build surfaces
     //c.bench_function("build_surfaces", |b| {
@@ -112,17 +112,12 @@ fn load_parameters(in_dir: &Path, params_path: &Path) -> Parameters {
     params
 }
 
-fn build_ledger(params: &Parameters) -> (Arc<Mutex<Ledger>>, Set<Material>) {
+fn build_ledger(params: &Parameters) -> (LedgerTree, Set<Material>) {
     let mut mats = params.mats.clone();
-    let ledger = Arc::new(Mutex::new(aetherus_events::ledger::Ledger::new()));
-    {
-        let mut ledger_guard = ledger.lock().expect("Failed to lock ledger.");
-
-        for name in mats.names_list() {
-            let mat = mats.get_mut(&name).unwrap();
-            *mat = mat.clone().with_id(ledger_guard.with_mat(name.to_string()));
-        }
-        drop(ledger_guard);
+    let mut ledger = LedgerTree::new();
+    for name in mats.names_list() {
+        let mat = mats.get_mut(&name).unwrap();
+        *mat = mat.clone().with_id(ledger.with_mat(name.to_string()));
     }
 
     (ledger, mats)
@@ -136,7 +131,7 @@ fn build_lights<'a>(params: &Parameters, mats: &'a Set<Material>) -> Set<Light<'
         .expect("Failed to link materials to lights.")
 }
 
-fn build_objects(params: &Parameters, base_output: &Output, ledger: &Arc<Mutex<Ledger>>, mats: &Set<Material>) -> Result<(Vec<Object>, Set<Attribute>), Error> {
+fn build_objects(params: &Parameters, base_output: &Output, ledger: &mut LedgerTree, mats: &Set<Material>) -> Result<(Vec<Object>, Set<Attribute>), Error> {
 
     let attrs_future = params
         .attrs
@@ -165,14 +160,13 @@ fn build_objects(params: &Parameters, base_output: &Output, ledger: &Arc<Mutex<L
         .collect();
 
     for obj in objs.iter_mut() {
-        let mut ledger_guard = ledger.lock().expect("Failed to lock ledger.");
         let src_id = match obj.attr {
             // TODO: Move this to allocate_ids inside Object struct
             Attribute::Interface(..) => {
-                ledger_guard.with_matsurf(obj.obj_name.clone(), obj.mat_name.clone().unwrap(), None)
+                ledger.with_matsurf(obj.obj_name.clone(), obj.mat_name.clone().unwrap(), None)
             },
             Attribute::Mirror(..) | Attribute::Reflector(..) => {
-                ledger_guard.with_surf(obj.obj_name.clone(), None)
+                ledger.with_surf(obj.obj_name.clone(), None)
             },
             _ => SrcId::None,
         };

--- a/benches/diffusion.rs
+++ b/benches/diffusion.rs
@@ -11,7 +11,7 @@ use aetherus::{
     sim::{Attribute, Parameters, ParametersBuilderLoader}
 };
 
-use aetherus_events::prelude::*;
+use events_ledger::prelude::*;
 use anyhow::Context;
 use criterion::{criterion_group, criterion_main, Criterion};
 use std::hint::black_box;

--- a/src/bin/mcrt.rs
+++ b/src/bin/mcrt.rs
@@ -20,7 +20,7 @@ use aetherus::{
         fmt::term,
     },
 };
-use aetherus_events::prelude::*;
+use events_ledger::prelude::*;
 
 /// Backup print width if the terminal width can not be determined.
 const BACKUP_TERM_WIDTH: usize = 80;
@@ -197,7 +197,7 @@ fn main() {
     if let Some(true) = sett.uid_tracked() {
         ledger_tree.resolve();
 
-        use aetherus_events::{pattern, filter::BitsProperty, ledger::write_ledger_to_json};
+        use events_ledger::{pattern, filter::BitsProperty, ledger::write_ledger_to_json};
         let no_detector_property = BitsProperty::NoMatch(pattern!(Detection, SrcId::None));
 
         let uids = ledger_tree.find_dangling_uids(no_detector_property);

--- a/src/bin/mcrt.rs
+++ b/src/bin/mcrt.rs
@@ -20,9 +20,7 @@ use aetherus::{
         fmt::term,
     },
 };
-use aetherus_events::SrcId;
-
-use std::sync::{Arc, Mutex};
+use aetherus_events::prelude::*;
 
 /// Backup print width if the terminal width can not be determined.
 const BACKUP_TERM_WIDTH: usize = 80;
@@ -46,20 +44,16 @@ fn main() {
     report!(bound, "boundary");
 
     section(term_width, "Ledger and materials setup");
-    let ledger = Arc::new(Mutex::new(aetherus_events::ledger::Ledger::new()));
+    let mut ledger_tree = LedgerTree::new();
 
     let mats = {
         let mut mats = params.mats;
         report!(mats, "materials");
 
-        let mut ledger_guard = ledger.lock().expect("Failed to lock ledger.");
-
         for name in mats.names_list() {
             let mat = mats.get_mut(&name).unwrap();
-            *mat = mat.clone().with_id(ledger_guard.with_mat(name.to_string()));
+            *mat = mat.clone().with_id(ledger_tree.with_mat(name.to_string()));
         }
-        drop(ledger_guard);
-
         mats
     };
 
@@ -115,14 +109,13 @@ fn main() {
         .collect();
 
     for obj in objs.iter_mut() {
-        let mut ledger_guard = ledger.lock().expect("Failed to lock ledger.");
         let src_id = match obj.attr {
             // TODO: Move this to allocate_ids inside Object struct
             Attribute::Interface(..) => {
-                ledger_guard.with_matsurf(obj.obj_name.clone(), obj.mat_name.clone().unwrap(), None)
+                ledger_tree.with_matsurf(obj.obj_name.clone(), obj.mat_name.clone().unwrap(), None)
             },
             Attribute::Mirror(..) | Attribute::Reflector(..) => {
-                ledger_guard.with_surf(obj.obj_name.clone(), None)
+                ledger_tree.with_surf(obj.obj_name.clone(), None)
             },
             _ => SrcId::None,
         };
@@ -169,7 +162,7 @@ fn main() {
             let input = Input::new(&base_output.reg.spec_reg, &mats, &attrs, &light, &tree, &sett, &bound);
 
             let data =
-                run::multi_thread(&engine, &input, &base_output, ledger.clone()).expect("Failed to run MCRT.");
+                run::multi_thread(&engine, &input, &base_output, &ledger_tree).expect("Failed to run MCRT.");
 
             // In the case that we are outputting the files for each individual light, we can output it here with a simple setting.
             if let Some(output_individual) = sett.output_individual_lights() {
@@ -182,6 +175,9 @@ fn main() {
                                 panic!("Unable to create output directory for light '{}'", light_id)
                             );
                     }
+                    // Resolve the UIDs before attempting to save data,
+                    // which may contain a PhotonCollector
+                    ledger_tree.resolve();
                     data.save(&indiv_outpath)
                         .unwrap_or_else(|_|
                             panic!("Failed to save output data for light '{}'", light_id)
@@ -195,22 +191,24 @@ fn main() {
 
     section(term_width, "Saving");
 
+
     let ledger_path = out_dir.join("simulation_ledger.json");
     println!("[SAVE] {}", ledger_path.display());
     if let Some(true) = sett.uid_tracked() {
-        use aetherus_events::{pattern, filter::find_dangling_uids, filter::BitsProperty};
+        ledger_tree.resolve();
+
+        use aetherus_events::{pattern, filter::BitsProperty, ledger::write_ledger_to_json};
         let no_detector_property = BitsProperty::NoMatch(pattern!(Detection, SrcId::None));
 
-        let uids = find_dangling_uids(&ledger.lock().expect("Failed to lock ledger."), no_detector_property);
+        let uids = ledger_tree.find_dangling_uids(no_detector_property);
         println!("[INFO] Found {} dangling UIDs to prune.", uids.len());
         for uid in uids {
-            ledger.lock().expect("Failed to lock ledger.").prune(&uid);
+            ledger_tree.prune_uid(&uid);
         }
 
-        aetherus_events::ledger::write_ledger_to_json(
-            &ledger.lock().expect("Failed to lock ledger."),
-            &ledger_path,
-        ).expect("Failed to save ledger.");
+        let ledger: Ledger = ledger_tree.into();
+
+        write_ledger_to_json(&ledger, &ledger_path).expect("Failed to save ledger.");
     }
 
     //report!(data, "data");

--- a/src/geom/domain/boundary.rs
+++ b/src/geom/domain/boundary.rs
@@ -6,7 +6,7 @@ use crate::{
     sim::Attribute,
     ord::cartesian::{X, Y, Z},
 };
-use aetherus_events::SrcId;
+use events_ledger::SrcId;
 use rand::Rng;
 use std::{fmt::{Display, Formatter}, marker::PhantomData};
 

--- a/src/geom/domain/object.rs
+++ b/src/geom/domain/object.rs
@@ -2,7 +2,7 @@
 
 use std::{fmt::Display, path::{Path, PathBuf}};
 
-use aetherus_events::SrcId;
+use events_ledger::SrcId;
 use anyhow::Context;
 use mesh_splitting::{Collide, IdxTriangle, Split, mesh::parse_obj, primitives::PrimitiveIdx};
 use serde::{Deserialize, Deserializer};

--- a/src/geom/domain/object.rs
+++ b/src/geom/domain/object.rs
@@ -426,6 +426,7 @@ impl Build for Scene {
 
         // Splitting of objects at the coplanar intersection with other meshes,
         // to ensure Attribute::Interface is correctly resolved
+        // FIXME: Split the meshes after SrcId allocation to the ledger
         let mut idx = objects.len();
         for i in 0..objects.len() {
             for j in i+1..meshes.len() {

--- a/src/io/output/photon_collector.rs
+++ b/src/io/output/photon_collector.rs
@@ -76,7 +76,7 @@ impl Save for PhotonCollector {
                     phot.power(),
                     phot.weight(),
                     phot.tof().unwrap_or(0.0),
-                    phot.uid().encode(),
+                    phot.node().map(|node| node.uid().unwrap().encode()).unwrap_or(0),
                 )?;
                 pb.tick();
             }

--- a/src/phys/local.rs
+++ b/src/phys/local.rs
@@ -1,7 +1,7 @@
 //! Local optical environment.
 
 use crate::clone;
-use aetherus_events::SrcId;
+use events_ledger::SrcId;
 
 /// Localised optical environment properties.
 #[derive(PartialEq, Clone, Debug)]

--- a/src/phys/material.rs
+++ b/src/phys/material.rs
@@ -3,7 +3,7 @@
 use crate::{access, fmt_report, math::Formula, phys::Local};
 use std::fmt::{Display, Error, Formatter};
 
-use aetherus_events::SrcId;
+use events_ledger::SrcId;
 
 /// Optical properties.
 #[derive(Clone, Debug, PartialEq)]

--- a/src/phys/photon.rs
+++ b/src/phys/photon.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use crate::{access, clone, geom::Ray};
 
-use aetherus_events::prelude::*;
+use events_ledger::prelude::*;
 
 #[cfg(feature = "mpi")]
 use crate::math::{Dir3, Point3};

--- a/src/phys/photon.rs
+++ b/src/phys/photon.rs
@@ -1,7 +1,9 @@
 //! Photon particle.
+use std::sync::Arc;
+
 use crate::{access, clone, geom::Ray};
 
-use aetherus_events::Uid;
+use aetherus_events::prelude::*;
 
 #[cfg(feature = "mpi")]
 use crate::math::{Dir3, Point3};
@@ -30,7 +32,7 @@ pub struct Photon {
     // less pressure on cache: https://craftspider.github.io/2024/09/shorts-boxing/
     tof: Option<f64>,
     /// Unique ID for Event logging
-    uid: Uid,
+    node: Option<Arc<LedgerNode>>,
 }
 
 impl Photon {
@@ -39,7 +41,18 @@ impl Photon {
     clone!(wavelength, wavelength_mut: f64);
     clone!(power: f64);
     clone!(tof, tof_mut: Option<f64>);
-    clone!(uid, uid_mut: Uid);
+
+    pub fn node(&self) -> Option<&Arc<LedgerNode>> {
+        self.node.as_ref()
+    }
+    pub fn update_node<F>(&mut self, f:F)
+    where
+        F: FnOnce(&Arc<LedgerNode>) -> Arc<LedgerNode>
+    {
+        if let Some(node) = &self.node {
+            self.node = Some(f(node));
+        }
+    }
 
     /// Construct a new instance.
     #[inline]
@@ -54,8 +67,13 @@ impl Photon {
             wavelength,
             power,
             tof: None,
-            uid: Uid::new(0, 0),
+            node: None,
         }
+    }
+
+    pub fn with_node(mut self, node: Arc<LedgerNode>) -> Self {
+        self.node = Some(node);
+        self
     }
 
     pub fn with_time(self) -> Self {

--- a/src/sim/engine/engine.rs
+++ b/src/sim/engine/engine.rs
@@ -10,9 +10,8 @@ use crate::{
 use ndarray::Array3;
 use rand::rngs::ThreadRng;
 use std::fmt::{Display, Error, Formatter};
-use std::sync::{Arc, Mutex};
 
-use aetherus_events::{ledger::Ledger, SrcId};
+use aetherus_events::prelude::*;
 
 /// Engine selection.
 #[allow(clippy::large_enum_variant)]
@@ -34,12 +33,11 @@ impl Engine {
         &self,
         input: &Input<(Attribute, SrcId)>,
         data: &mut Output,
-        ledger: &Arc<Mutex<Ledger>>,
         rng: &mut ThreadRng,
         phot: Photon,
     ) {
         match *self {
-            Self::Standard => engines::standard(input, data, ledger, rng, phot),
+            Self::Standard => engines::standard(input, data, rng, phot),
             Self::Raman(ref p) => engines::raman(p, input, data, rng, phot),
             Self::Photo(ref frames, _res) => engines::photo(frames, input, data, rng, phot),
             Self::Fluorescence(ref shift_map, ref conc_spec) => {

--- a/src/sim/engine/engine.rs
+++ b/src/sim/engine/engine.rs
@@ -11,7 +11,7 @@ use ndarray::Array3;
 use rand::rngs::ThreadRng;
 use std::fmt::{Display, Error, Formatter};
 
-use aetherus_events::prelude::*;
+use events_ledger::prelude::*;
 
 /// Engine selection.
 #[allow(clippy::large_enum_variant)]

--- a/src/sim/engine/engines/fluorescence.rs
+++ b/src/sim/engine/engines/fluorescence.rs
@@ -92,7 +92,7 @@ pub fn fluorescence(
             }
             Event::Surface(hit) => {
                 travel(&mut phot, &env, hit.dist());
-                surface(&mut rng, &hit, &mut phot, &mut local, data, None);
+                surface(&mut rng, &hit, &mut phot, &mut local, data);
                 travel(&mut phot, &env, bump_dist);
             }
             Event::Boundary(boundary_hit) => {

--- a/src/sim/engine/engines/fluorescence.rs
+++ b/src/sim/engine/engines/fluorescence.rs
@@ -6,7 +6,7 @@ use crate::{
     phys::{Local, Photon},
     sim::{Attribute, Event, Input, scatter::scatter, surface::surface, travel::travel},
 };
-use aetherus_events::SrcId;
+use events_ledger::SrcId;
 use ndarray::Array3;
 use rand::{rngs::ThreadRng, RngExt};
 

--- a/src/sim/engine/engines/photo.rs
+++ b/src/sim/engine/engines/photo.rs
@@ -87,7 +87,7 @@ pub fn photo(
             }
             Event::Surface(hit) => {
                 travel(&mut phot, &env, hit.dist());
-                surface(&mut rng, &hit, &mut phot, &mut env, data, None);
+                surface(&mut rng, &hit, &mut phot, &mut env, data);
                 travel(&mut phot, &env, bump_dist);
             },
             Event::Boundary(boundary_hit) => {

--- a/src/sim/engine/engines/photo.rs
+++ b/src/sim/engine/engines/photo.rs
@@ -5,7 +5,7 @@ use crate::{
         Attribute, Event, Frame, Input, peel_off::peel_off, scatter::scatter, surface::surface, travel::travel
     }
 };
-use aetherus_events::SrcId;
+use events_ledger::SrcId;
 use rand::{rngs::ThreadRng, RngExt};
 
 /// Photograph the life of a single photon.

--- a/src/sim/engine/engines/raman.rs
+++ b/src/sim/engine/engines/raman.rs
@@ -3,7 +3,7 @@
 use crate::{
     io::output::{Output, OutputParameter}, math::Point3, phys::Photon, sim::{Attribute, Event, Input, scatter::shift_scatter, surface::surface, travel::travel}
 };
-use aetherus_events::SrcId;
+use events_ledger::SrcId;
 use rand::{rngs::ThreadRng, RngExt};
 
 /// Simulate the life of a single photon which has the potential to generate a Raman photon.

--- a/src/sim/engine/engines/raman.rs
+++ b/src/sim/engine/engines/raman.rs
@@ -78,7 +78,7 @@ pub fn raman(
             }
             Event::Surface(hit) => {
                 travel(&mut phot, &env, hit.dist());
-                surface(&mut rng, &hit, &mut phot, &mut env, data, None);
+                surface(&mut rng, &hit, &mut phot, &mut env, data);
                 travel(&mut phot, &env, bump_dist);
             },
             Event::Boundary(boundary_hit) => {

--- a/src/sim/engine/engines/standard.rs
+++ b/src/sim/engine/engines/standard.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use rand::{Rng, RngExt};
 
-use aetherus_events::prelude::*;
+use events_ledger::prelude::*;
 
 /// Simulate the life of a single photon.
 #[allow(clippy::expect_used)]

--- a/src/sim/engine/engines/standard.rs
+++ b/src/sim/engine/engines/standard.rs
@@ -6,16 +6,14 @@ use crate::{
     sim::{Attribute, Event, Input, scatter::scatter, surface::surface, travel::travel},
 };
 use rand::{Rng, RngExt};
-use std::sync::{Arc, Mutex};
 
-use aetherus_events::{EventType, SrcId, ledger::Ledger};
+use aetherus_events::prelude::*;
 
 /// Simulate the life of a single photon.
 #[allow(clippy::expect_used)]
 pub fn standard<R: Rng>(
     input: &Input<(Attribute, SrcId)>,
     data: &mut Output,
-    ledger: &Arc<Mutex<Ledger>>,
     mut rng: &mut R,
     mut phot: Photon,
 ) {
@@ -88,9 +86,7 @@ pub fn standard<R: Rng>(
                 // considerably. Consider using an async design, encapsulating `uid` in work token
                 // and computed value, transforming insert into a send on an mpsc channel
                 if input.sett.uid_tracked() == Some(true) {
-                    *phot.uid_mut() = ledger.lock()
-                                            .expect("Can't lock Ledger")
-                                            .insert(phot.uid(), event_id);
+                    phot.update_node(|node| node.insert(event_id));
 
                 }
                 // Reset scat_dist for the new scattering event
@@ -98,15 +94,10 @@ pub fn standard<R: Rng>(
             }
             Event::Surface(hit) => {
                 travel(&mut phot, &env, hit.dist());
-                // FIXME: next_seq_id needed here only for PhotonCollector, which needs the updated
-                // Uid before it can store the photon data. How to solve this RAW hazard?
-                let next_seq_id = ledger.lock().expect("Can't lock Ledger").get_next_seq_id(&phot.uid());
-                let event_id = surface(&mut rng, &hit, &mut phot, &mut env, data, next_seq_id);
+                let event_id = surface(&mut rng, &hit, &mut phot, &mut env, data);
                 phot.ray_mut().travel(bump_dist);
-                if input.sett.uid_tracked() == Some(true) && event_id.event_type != EventType::None {
-                    *phot.uid_mut() = ledger.lock()
-                                            .expect("Can't lock Ledger")
-                                            .insert(phot.uid(), event_id);
+                if input.sett.uid_tracked() == Some(true) && event_id.event_type != EventType::None && phot.weight() > 0.0 {
+                    phot.update_node(|node| node.insert(event_id));
                 }
 
                 // FIXME: Is the surface interaction also affecting the scattering statistics like

--- a/src/sim/peel_off.rs
+++ b/src/sim/peel_off.rs
@@ -5,7 +5,7 @@ use crate::{
     phys::{Local, Photon},
     sim::{Attribute, Input},
 };
-use aetherus_events::SrcId;
+use events_ledger::SrcId;
 use nalgebra::distance;
 
 /// Minimum weight before discarding during peel-off.

--- a/src/sim/run.rs
+++ b/src/sim/run.rs
@@ -18,7 +18,7 @@ pub fn multi_thread<'a>(
     engine: &Engine,
     input: &'a Input<'a, (Attribute, SrcId)>,
     output: &Output,
-    ledger: Arc<Mutex<Ledger>>,
+    ledger: &LedgerTree,
 ) -> Result<Output, Error> {
     let pb = ProgressBar::new("MCRT", input.sett.num_phot());
     let pb = Arc::new(Mutex::new(pb));
@@ -36,7 +36,7 @@ pub fn multi_thread<'a>(
                 engine,
                 input,
                 output.clone(),
-                ledger.clone(),
+                ledger.root().clone(),
                 &Arc::clone(&pb),
             )
         })
@@ -58,7 +58,7 @@ fn thread<'a>(
     engine: &Engine,
     input: &'a Input<'a, (Attribute, SrcId)>,
     mut output: Output,
-    ledger: Arc<Mutex<Ledger>>,
+    ledger_root: Arc<LedgerNode>,
     pb: &Arc<Mutex<ProgressBar>>,
 ) -> Output {
     let mut rng = rng();
@@ -78,10 +78,10 @@ fn thread<'a>(
             // FIXME: Replace emission_type and light_id placeholder witha actual values from
             // input.light
             if input.sett.uid_tracked() == Some(true) {
-                *phot.uid_mut() = ledger
-                    .lock()
-                    .expect("Could not lock ledger.")
-                    .insert_start(EventId::new_emission(Emission::GaussianBeam, SrcId::Light(0)));
+                phot = phot.with_node(
+                    ledger_root
+                        .insert(EventId::new_emission(Emission::GaussianBeam, SrcId::Light(0)))
+                );
             }
 
             if input.sett.time_resolved() == Some(true) {
@@ -89,7 +89,7 @@ fn thread<'a>(
             }
             // FIXME: Locking here and waiting for engine to run essentially transform this into a
             // very inefficient sequential (non parallel threaded) program
-            engine.run(input, &mut output, &ledger, &mut rng, phot);
+            engine.run(input, &mut output, &mut rng, phot);
         }
     }
 

--- a/src/sim/run.rs
+++ b/src/sim/run.rs
@@ -7,8 +7,8 @@ use rand::rng;
 use rayon::prelude::*;
 use std::sync::{Arc, Mutex};
 
-use aetherus_events::prelude::*;
-use aetherus_events::events::Emission;
+use events_ledger::prelude::*;
+use events_ledger::events::Emission;
 
 /// Run a multi-threaded MCRT simulation.
 /// # Errors

--- a/src/sim/scatter.rs
+++ b/src/sim/scatter.rs
@@ -4,7 +4,7 @@ use crate::{
     math::sample_henyey_greenstein,
     phys::{Local, Photon},
 };
-use aetherus_events::{EventId, EventType, mcrt_event};
+use events_ledger::{EventId, EventType, mcrt_event};
 use rand::{Rng, RngExt};
 use std::f64::consts::PI;
 

--- a/src/sim/surface.rs
+++ b/src/sim/surface.rs
@@ -17,7 +17,6 @@ pub fn surface<R: Rng>(
     phot: &mut Photon,
     env: &mut Local,
     data: &mut Output,
-    seq_id: Option<u32>,
 ) -> EventId {
     match hit.tag().0 {
         Attribute::Interface(ref inside, ref outside) => {
@@ -91,15 +90,9 @@ pub fn surface<R: Rng>(
                 // FIXME: The photon collection happens before the new Uid is updated in the
                 // photon, hence this is a very ugly walk-around to fix this issues which needs to be
                 // sorted out properly.
-                let mut future_phot = phot.clone();
                 let event_id = EventId { event_type: EventType::Detection, src_id: hit.tag().1 };
-                if let Some(seq_id) = seq_id {
-                    *future_phot.uid_mut() = Uid::from_event(seq_id, &event_id);
-                }
-                data.phot_cols[id].collect_photon(&mut future_phot);
-                if future_phot.weight() <= 0.0 {
-                    phot.kill();
-                }
+                phot.update_node(|node| node.insert(&event_id));
+                data.collect_photon(phot, id);
                 event_id
             } else {
                 EventId { event_type: EventType::None, src_id: hit.tag().1 }

--- a/src/sim/surface.rs
+++ b/src/sim/surface.rs
@@ -6,7 +6,7 @@ use crate::{
     phys::{Crossing, Local, Photon},
     sim::Attribute,
 };
-use aetherus_events::prelude::*;
+use events_ledger::prelude::*;
 use rand::{Rng, RngExt};
 
 /// Handle a surface collision.


### PR DESCRIPTION
Ledger is now represented in 2 equivalent structures `Ledger` and `LedgerTree`, such that during the simulation the LedgerTree is used, described internally by a tree formed of `LedgerNode`.

Previously the photon packets were holding `Uid`, however, that required for insertion to perform a lookup in the Ledger every time, even though we already now the element that needs to be accessed from previous allocation.
Furthermore, during simulation the `seq_id` which need to be allocated uniquely for each new UID value, is not needed for building the chain of events.

Now the photon packets hold an `Arc<LedgerNode>` that only need to mutate its list of children upon a new allocation. This map is hold under a `RwLock` internally, hence the API does need to concern itself to how this mechanism works.

Only thing to be aware of now, is that we need to resolve the `seq_id` values in the tree before we convert `LedgerTree` to `Ledger`, such that we can serialize it out.